### PR TITLE
[FEAT] 그룹 정보 및 그룹 문제집 리스트 페이지 퍼블리싱

### DIFF
--- a/src/app/group/(layout)/_components/GroupCard/Name.tsx
+++ b/src/app/group/(layout)/_components/GroupCard/Name.tsx
@@ -1,7 +1,8 @@
+import Link from 'next/link'
 import { useGroupCardContext } from './GroupCardContext'
 
 export default function Name() {
-    const { name } = useGroupCardContext()
+    const { name, _id } = useGroupCardContext()
 
     if (!name) {
         return null
@@ -9,7 +10,7 @@ export default function Name() {
 
     return (
         <h3 className="cursor-pointer text-mobile-body-lg font-semi-bold md:text-pc-body-lg">
-            {name}
+            <Link href={`/group/${_id}`}>{name}</Link>
         </h3>
     )
 }

--- a/src/app/group/(layout)/layout.tsx
+++ b/src/app/group/(layout)/layout.tsx
@@ -1,8 +1,4 @@
 import MobileBottomNav from '@/components/MobileBottomNav'
-import BottomHome from '@/assets/svgs/bottom-home.svg'
-import BottomQuizbook from '@/assets/svgs/bottom-quizbook.svg'
-import BottomGroup from '@/assets/svgs/bottom-group.svg'
-import BottomMyStatus from '@/assets/svgs/bottom-my-status.svg'
 
 export default function GroupMobileLayout({
     children,
@@ -15,23 +11,7 @@ export default function GroupMobileLayout({
             {children}
 
             {/* 모바일 전용 바텀 Nav */}
-            <MobileBottomNav>
-                <MobileBottomNav.MenuItem text="홈" href="/">
-                    <BottomHome />
-                </MobileBottomNav.MenuItem>
-                <MobileBottomNav.MenuItem text="문제집" href="/quizbook">
-                    <BottomQuizbook />
-                </MobileBottomNav.MenuItem>
-                <MobileBottomNav.MenuItem text="그룹" href="/group">
-                    <BottomGroup />
-                </MobileBottomNav.MenuItem>
-                <MobileBottomNav.UserMenuItem
-                    text="학습현황"
-                    href="/study-status"
-                >
-                    <BottomMyStatus />
-                </MobileBottomNav.UserMenuItem>
-            </MobileBottomNav>
+            <MobileBottomNav />
         </>
     )
 }

--- a/src/app/group/[groupId]/_components/GroupInfo.tsx
+++ b/src/app/group/[groupId]/_components/GroupInfo.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import { CustomInput, LoopAnimation, ProfileImage } from '@/components'
+import { zodResolver } from '@hookform/resolvers/zod'
+import clsx from 'clsx'
+import { useEffect, useState } from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
+import * as z from 'zod'
+
+const schema = z.object({
+    name: z
+        .string()
+        .min(3, { message: '그룹 이름은 3자 이상으로 해주세요' })
+        .max(20, { message: '그룹 이름은 20자 이하로 해주세요' }),
+    description: z
+        .string()
+        .min(1, { message: '그룹 소개는 꼭 입력해주세요' })
+        .max(50, { message: '그룹 소개는 50자 이하로 해주세요' }),
+})
+
+type FormData = z.infer<typeof schema>
+
+export default function GroupInfo() {
+    const [isLoading, setIsLoading] = useState(false)
+    const [isChangeMode, setIsChangeMode] = useState(false)
+    const [backUp, setBackUp] = useState({
+        name: '',
+        description: '',
+    })
+    const methods = useForm<FormData>({
+        resolver: zodResolver(schema),
+        mode: 'onChange',
+        defaultValues: backUp,
+    })
+
+    const { reset } = methods
+
+    useEffect(() => {
+        reset({
+            name: '봄바르딜로 크로커딜로',
+            description: '퉁퉁퉁퉁퉁퉁 사후르',
+        })
+        setBackUp({
+            name: '봄바르딜로 크로커딜로',
+            description: '퉁퉁퉁퉁퉁퉁 사후르',
+        })
+    }, [reset, setBackUp])
+
+    const handleFormSubmit = async (data: FormData) => {
+        // 추후 로직 수정
+        setIsLoading(true)
+        setTimeout(() => {
+            console.log('Form Data:', data)
+            setIsLoading(false)
+            setBackUp(data)
+            setIsChangeMode(false)
+        }, 2000)
+    }
+    const handleCancel = () => {
+        reset(backUp)
+        setIsChangeMode(false)
+    }
+
+    return (
+        <section className="w-full rounded-lg bg-white p-4 shadow-point md:p-8">
+            <FormProvider {...methods}>
+                <form
+                    onSubmit={methods.handleSubmit(handleFormSubmit)}
+                    className="flex w-full flex-col items-center gap-3"
+                >
+                    <div className="flex w-full flex-col gap-4">
+                        <CustomInput
+                            id="name"
+                            name="name"
+                            label="그룹 이름"
+                            placeholder="그룹 이름을 입력해주세요"
+                            style="solid"
+                            error={methods.formState.errors.name?.message}
+                            disabled={isLoading || !isChangeMode}
+                        />
+                        <CustomInput
+                            id="description"
+                            name="description"
+                            label="그룹 소개(50자 이하)"
+                            placeholder="그룹 소개를 입력해주세요"
+                            style="solid"
+                            error={
+                                methods.formState.errors.description?.message
+                            }
+                            disabled={isLoading || !isChangeMode}
+                        />
+                        <div className="flex w-full gap-4 pb-4">
+                            <div className="flex flex-1 flex-col items-start gap-1">
+                                <span className="text-mobile-body-sm font-regular text-gray-500 md:text-pc-body-sm">
+                                    그룹장
+                                </span>
+                                <div className="flex cursor-pointer items-center gap-2">
+                                    <ProfileImage size={32} profileImg={''} />
+                                    <span className="text-mobile-body-md font-semi-bold md:text-pc-body-md">
+                                        닉네임
+                                    </span>
+                                </div>
+                            </div>
+                            <div className="flex flex-1 flex-col items-start gap-1">
+                                <span className="text-mobile-body-sm font-regular text-gray-500 md:text-pc-body-sm">
+                                    그룹 생성일
+                                </span>
+                                <span className="text-mobile-body-md font-semi-bold md:text-pc-body-md">
+                                    2025-03-21
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                    {isChangeMode ? (
+                        <div className="flex w-full gap-[10px]">
+                            <button
+                                disabled={isLoading}
+                                className="btn-outline btn-mobile-lg flex-1 md:btn-pc-lg"
+                                onClick={handleCancel}
+                            >
+                                취소
+                            </button>
+                            <button
+                                type="submit"
+                                disabled={isLoading}
+                                className={clsx(
+                                    'btn-solid btn-mobile-lg flex-1 md:btn-pc-lg',
+                                    isLoading && 'btn-loading',
+                                )}
+                            >
+                                {isLoading && <LoopAnimation />}
+                                {isLoading ? 'Loading...' : '저장'}
+                            </button>
+                        </div>
+                    ) : (
+                        <button
+                            className="btn-solid btn-mobile-lg w-full flex-1 md:btn-pc-lg"
+                            onClick={() => setIsChangeMode(true)}
+                        >
+                            수정하기
+                        </button>
+                    )}
+                </form>
+            </FormProvider>
+        </section>
+    )
+}

--- a/src/app/group/[groupId]/layout.tsx
+++ b/src/app/group/[groupId]/layout.tsx
@@ -1,0 +1,49 @@
+import Sidebar from '@/components/Sidebar'
+import InfoIcon from '@/assets/svgs/info.svg'
+import NoteIcon from '@/assets/svgs/note.svg'
+import GroupChatIcon from '@/assets/svgs/group-chat.svg'
+import MemberIcon from '@/assets/svgs/member.svg'
+
+export default async function GroupSidebarLayout({
+    children,
+    params,
+}: Readonly<{
+    children: React.ReactNode
+    params: Promise<{ groupId: string }>
+}>) {
+    const { groupId } = await params
+
+    return (
+        <div className="flex w-full max-w-[1056px] flex-col gap-4 md:flex-row md:gap-8 md:px-4 md:py-8">
+            <div className="hidden w-[230px] md:block">
+                <Sidebar gap={4}>
+                    <Sidebar.Group>
+                        <Sidebar.Item
+                            icon={<InfoIcon className="size-5" />}
+                            text="그룹 정보"
+                            href={`/group/${groupId}`}
+                        />
+                    </Sidebar.Group>
+                    <Sidebar.Group>
+                        <Sidebar.Item
+                            icon={<NoteIcon className="size-5" />}
+                            text="선정 문제집"
+                            href={`/group/${groupId}/quizbook`}
+                        />
+                        <Sidebar.Item
+                            icon={<GroupChatIcon className="size-5" />}
+                            text="그룹 채팅"
+                            href={`/group/${groupId}/chat`}
+                        />
+                        <Sidebar.Item
+                            icon={<MemberIcon className="size-5" />}
+                            text="멤버 관리"
+                            href={`/group/${groupId}/member`}
+                        />
+                    </Sidebar.Group>
+                </Sidebar>
+            </div>
+            {children}
+        </div>
+    )
+}

--- a/src/app/group/[groupId]/page.tsx
+++ b/src/app/group/[groupId]/page.tsx
@@ -3,6 +3,7 @@ import NoteIcon from '@/assets/svgs/note.svg'
 import GroupChatIcon from '@/assets/svgs/group-chat.svg'
 import MemberIcon from '@/assets/svgs/member.svg'
 import Sidebar from '@/components/Sidebar'
+import GroupInfo from './_components/GroupInfo'
 
 export default async function GroupInfoPage({
     params,
@@ -17,12 +18,12 @@ export default async function GroupInfoPage({
             <MobileHeader title="그룹 정보" backBtn />
 
             {/* 컨탠츠 */}
-            <main className="flex w-full flex-1 flex-col items-center overflow-auto">
-                <div className="flex w-full flex-col gap-4 px-4 md:px-0">
+            <main className="flex w-full flex-1 flex-col items-center overflow-visible">
+                <div className="flex w-full flex-col gap-4 px-4 pb-4 md:px-0 md:pb-0">
                     <h2 className="hidden text-pc-title-sm font-extra-bold text-point-900 md:block">
                         그룹 정보
                     </h2>
-
+                    <GroupInfo />
                     <div className="w-full md:hidden">
                         <Sidebar gap={4}>
                             <Sidebar.Group>

--- a/src/app/group/[groupId]/page.tsx
+++ b/src/app/group/[groupId]/page.tsx
@@ -1,12 +1,20 @@
 import MobileHeader from '@/components/MobileHeader'
+import NoteIcon from '@/assets/svgs/note.svg'
+import GroupChatIcon from '@/assets/svgs/group-chat.svg'
+import MemberIcon from '@/assets/svgs/member.svg'
+import Sidebar from '@/components/Sidebar'
 
-export default function GroupInfoPage() {
+export default async function GroupInfoPage({
+    params,
+}: Readonly<{
+    params: Promise<{ groupId: string }>
+}>) {
+    const { groupId } = await params
+
     return (
         <>
             {/* 모바일 전용 헤더 */}
-            <MobileHeader title="그룹 정보" backBtn>
-                <MobileHeader.UserMenu />
-            </MobileHeader>
+            <MobileHeader title="그룹 정보" backBtn />
 
             {/* 컨탠츠 */}
             <main className="flex w-full flex-1 flex-col items-center overflow-auto">
@@ -14,7 +22,28 @@ export default function GroupInfoPage() {
                     <h2 className="hidden text-pc-title-sm font-extra-bold text-point-900 md:block">
                         그룹 정보
                     </h2>
-                    hi
+
+                    <div className="w-full md:hidden">
+                        <Sidebar gap={4}>
+                            <Sidebar.Group>
+                                <Sidebar.Item
+                                    icon={<NoteIcon className="size-5" />}
+                                    text="선정 문제집"
+                                    href={`/group/${groupId}/quizbook`}
+                                />
+                                <Sidebar.Item
+                                    icon={<GroupChatIcon className="size-5" />}
+                                    text="그룹 채팅"
+                                    href={`/group/${groupId}/chat`}
+                                />
+                                <Sidebar.Item
+                                    icon={<MemberIcon className="size-5" />}
+                                    text="멤버 관리"
+                                    href={`/group/${groupId}/member`}
+                                />
+                            </Sidebar.Group>
+                        </Sidebar>
+                    </div>
                 </div>
             </main>
         </>

--- a/src/app/group/[groupId]/page.tsx
+++ b/src/app/group/[groupId]/page.tsx
@@ -1,0 +1,22 @@
+import MobileHeader from '@/components/MobileHeader'
+
+export default function GroupInfoPage() {
+    return (
+        <>
+            {/* 모바일 전용 헤더 */}
+            <MobileHeader title="그룹 정보" backBtn>
+                <MobileHeader.UserMenu />
+            </MobileHeader>
+
+            {/* 컨탠츠 */}
+            <main className="flex w-full flex-1 flex-col items-center overflow-auto">
+                <div className="flex w-full flex-col gap-4 px-4 md:px-0">
+                    <h2 className="hidden text-pc-title-sm font-extra-bold text-point-900 md:block">
+                        그룹 정보
+                    </h2>
+                    hi
+                </div>
+            </main>
+        </>
+    )
+}

--- a/src/app/group/[groupId]/quizbook/_components/GroupQuizbookSearch.tsx
+++ b/src/app/group/[groupId]/quizbook/_components/GroupQuizbookSearch.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { QuizbookCard } from '@/components'
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select'
+import { QuizbookCardStatus } from '@/constants/common/quizbookBadge'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import RightArrowIcon from '@/assets/svgs/right-arrow.svg'
+
+const dummyDatas = [
+    {
+        group: '65e8a5d6fc13ae5e7f000002',
+        quizbook: {
+            _id: '65e8a5d6fc13ae5e7f000001',
+            title: '알고리즘 문제집',
+            description: '면접 준비용',
+            category: '알고리즘',
+            author: {
+                _id: '유저ID',
+                nickname: '유저 닉네임',
+                profileImg: '',
+            },
+            solvedCount: 100,
+            solvedRate: 85.5,
+        },
+        endedAt: '2025-04-02',
+    },
+    {
+        group: '65e8a5d6fc13ae5e7f000002',
+        quizbook: {
+            _id: '65e8a5d6fc13ae5e7f000002',
+            title: '알고리즘 문제집',
+            description: '면접 준비용',
+            category: '알고리즘',
+            author: {
+                _id: '유저ID',
+                nickname: '유저 닉네임',
+                profileImg: '',
+            },
+            solvedCount: 100,
+            solvedRate: 85.5,
+        },
+        endedAt: '2025-04-02',
+    },
+]
+
+export default function GroupQuizbookSearch({ groupId }: { groupId: string }) {
+    const router = useRouter()
+
+    const handleQuizbookCardClick = () => {
+        console.log(1)
+    }
+
+    return (
+        <div className="flex flex-col gap-4">
+            <div className="flex items-center justify-between">
+                <div className="flex items-center gap-4">
+                    <Select defaultValue="in-progress">
+                        <SelectTrigger className="w-auto gap-[5px] rounded-lg border-2 border-gray-200 bg-white px-[15px] py-[7.5px] text-mobile-body-sm font-regular text-gray-900 md:gap-2 md:px-6 md:py-5 md:text-pc-body-md">
+                            <SelectValue placeholder="Status" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="in-progress">진행중</SelectItem>
+                            <SelectItem value="complete">마감 완료</SelectItem>
+                        </SelectContent>
+                    </Select>
+                    <div className="text-mobile-body-md font-semi-bold md:text-pc-body-md">
+                        {'1,026'}개의 결과
+                    </div>
+                </div>
+                <button
+                    className="btn-solid btn-mobile-sm md:btn-pc-md"
+                    onClick={() => router.push('/quizbook')}
+                >
+                    문제집 추가
+                </button>
+            </div>
+            {dummyDatas.map((data) => (
+                <QuizbookCard
+                    key={data.quizbook._id}
+                    id={data.quizbook._id}
+                    category={data.quizbook.category}
+                    title={data.quizbook.title}
+                    description={data.quizbook.description}
+                    author={{
+                        nickname: data.quizbook.author.nickname,
+                        profileImg: data.quizbook.author.profileImg,
+                    }}
+                    solvedRate={78.5}
+                    solvedCount={36}
+                    badge={{
+                        status: QuizbookCardStatus.COMPLETED,
+                        customText: '완료',
+                    }}
+                    onClick={handleQuizbookCardClick}
+                >
+                    <QuizbookCard.Description />
+                    <div className="flex w-full items-end justify-between">
+                        <QuizbookCard.Author />
+                        <div className="text-mobile-body-sm font-semi-bold md:text-pc-body-sm">
+                            마감일:{' '}
+                            <span className="text-mobile-body-sm font-semi-bold text-point-500 md:text-pc-body-sm">
+                                {'2025-03-28'}
+                            </span>
+                        </div>
+                    </div>
+                    <div className="flex w-full items-end justify-between">
+                        <QuizbookCard.SolvedRate />
+                        <Link
+                            href={`/group/${groupId}/quizbook/${data.quizbook._id}`}
+                            className="flex cursor-pointer items-center gap-1 text-point-500"
+                        >
+                            <span className="text-mobile-body-sm font-semi-bold md:text-pc-body-sm">
+                                그룹원 풀이 보기
+                            </span>
+                            <RightArrowIcon className="size-5 md:size-6" />
+                        </Link>
+                    </div>
+                </QuizbookCard>
+            ))}
+        </div>
+    )
+}

--- a/src/app/group/[groupId]/quizbook/page.tsx
+++ b/src/app/group/[groupId]/quizbook/page.tsx
@@ -1,6 +1,13 @@
 import MobileHeader from '@/components/MobileHeader'
+import GroupQuizbookSearch from './_components/GroupQuizbookSearch'
 
-export default function GroupQuizbookPage() {
+export default async function GroupQuizbookPage({
+    params,
+}: Readonly<{
+    params: Promise<{ groupId: string }>
+}>) {
+    const { groupId } = await params
+
     return (
         <>
             {/* 모바일 전용 헤더 */}
@@ -12,7 +19,7 @@ export default function GroupQuizbookPage() {
                     <h2 className="hidden text-pc-title-sm font-extra-bold text-point-900 md:block">
                         그룹 선정 문제집
                     </h2>
-                    {/* 클라이언트 컴포넌트 */}
+                    <GroupQuizbookSearch groupId={groupId} />
                 </div>
             </main>
         </>

--- a/src/app/group/[groupId]/quizbook/page.tsx
+++ b/src/app/group/[groupId]/quizbook/page.tsx
@@ -1,0 +1,20 @@
+import MobileHeader from '@/components/MobileHeader'
+
+export default function GroupQuizbookPage() {
+    return (
+        <>
+            {/* 모바일 전용 헤더 */}
+            <MobileHeader title="그룹 선정 문제집" backBtn />
+
+            {/* 컨탠츠 */}
+            <main className="flex w-full flex-1 flex-col items-center overflow-visible">
+                <div className="flex w-full flex-col gap-4 px-4 pb-4 md:px-0 md:pb-0">
+                    <h2 className="hidden text-pc-title-sm font-extra-bold text-point-900 md:block">
+                        그룹 선정 문제집
+                    </h2>
+                    {/* 클라이언트 컴포넌트 */}
+                </div>
+            </main>
+        </>
+    )
+}

--- a/src/app/group/layout.tsx
+++ b/src/app/group/layout.tsx
@@ -8,13 +8,7 @@ export default function GroupDesktopLayout({
     return (
         <div className="flex h-screen flex-col items-center bg-point-50 text-gray-900">
             {/* 데스크탑 전용 헤더 */}
-            <DesktopHeader>
-                <nav className="flex">
-                    <DesktopHeader.MenuItem text="문제집" href="/quizbook" />
-                    <DesktopHeader.MenuItem text="그룹" href="/group" />
-                </nav>
-                <DesktopHeader.UserMenu />
-            </DesktopHeader>
+            <DesktopHeader />
 
             {/* 컨탠츠 */}
             {children}


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
- 그룹 정보 페이지와 그룹 문제집 리스트 페이지 퍼블리싱을 완료했습니다.

## 📌 이슈 넘버
- #18 

## 📝 작업 내용

- 그룹 사이드바 레이아웃 작성
- 그룹 정보 페이지 퍼블리싱
- 그룹 문제집 리스트 페이지 퍼블리싱

## 📸 스크린샷(선택)

### 그룹 정보 페이지
![chrome-capture-2025-4-21](https://github.com/user-attachments/assets/c2010ad8-ec8e-4c75-9457-f6a304333e31)
![chrome-capture-2025-4-2](https://github.com/user-attachments/assets/7103ea5f-650f-4146-afb2-4ef1f158d11c)

### 그룹 문제집 리스트 페이지
![chrome-capture-2025-4](https://github.com/user-attachments/assets/587292cc-a50e-423a-bb2f-5e83022d808a)
<img width="280" alt="화면 캡처 2025-04-21 230937" src="https://github.com/user-attachments/assets/b1d62022-bf57-4d2c-a0ea-997326e748d0" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
