### PR TITLE
[Feat] 문제집카드 클릭 이벤트 수정

### DIFF
--- a/src/components/QuizbookCard/QuizbookCardRoot.tsx
+++ b/src/components/QuizbookCard/QuizbookCardRoot.tsx
@@ -40,17 +40,19 @@ export default function QuizbookCardRoot({
         <QuizbookCardContext.Provider value={{ id, category, title, ...props }}>
             <div
                 className={clsx(
-                    'flex cursor-pointer flex-col items-start gap-2 rounded-lg bg-white p-4 shadow-point hover:bg-gray-100',
+                    'flex flex-col items-start gap-2 rounded-lg bg-white p-4 shadow-point hover:bg-gray-100',
                     className,
                 )}
-                onClick={handleQuizbookCardClick}
             >
                 <div className="flex w-full gap-1">
                     <div className="flex-1">
                         <div className="text-mobile-caption font-regular text-point-500 md:text-pc-caption">
                             {category}
                         </div>
-                        <div className="line-clamp-1 text-mobile-body-lg font-semi-bold md:text-pc-body-lg">
+                        <div
+                            className="line-clamp-1 cursor-pointer text-mobile-body-lg font-semi-bold md:text-pc-body-lg"
+                            onClick={handleQuizbookCardClick}
+                        >
                             {title}
                         </div>
                     </div>

--- a/src/components/QuizbookCard/QuizbookCardRoot.tsx
+++ b/src/components/QuizbookCard/QuizbookCardRoot.tsx
@@ -63,10 +63,3 @@ export default function QuizbookCardRoot({
         </QuizbookCardContext.Provider>
     )
 }
-
-// QuizbookCard.Description = Description
-// QuizbookCard.Author = Author
-// QuizbookCard.SolvedRate = SolvedRate
-// QuizbookCard.ReviewRate = ReviewRate
-// QuizbookCard.QuizCount = QuizCount
-// QuizbookCard.LikeButton = LikeButton


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

문제집카드 클릭 이벤트를 최상위 요소에서 제목 요소로 이동

## 📌 이슈 넘버

- #25

## 📝 작업 내용

문제집카드 클릭 이벤트를 최상위 요소에서 제목 요소로 이동했습니다. 이에 따라 사용자에게 클릭 가능한 영역을 명확히 전달하기 위해, 기존에 최상위 요소에 적용되어 있던 cursor-pointer 스타일도 제목 요소로 함께 이동했습니다.

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

