### PR TITLE
[Feat] 문제집 생성 페이지 구현

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -35,7 +35,7 @@
     border-radius: 8px;
 }
 
-/* Input 자동 입력시 브라우저 기본 CSS 방지지 */
+/* Input 자동 입력시 브라우저 기본 CSS 방지 */
 input:-webkit-autofill,
 input:-webkit-autofill:hover,
 input:-webkit-autofill:focus,
@@ -62,7 +62,7 @@ input:autofill:disabled {
 }
 
 @layer base {
-  :root {
+    :root {
         --background: 0 0% 100%;
         --foreground: 224 71.4% 4.1%;
         --card: 0 0% 100%;
@@ -89,7 +89,7 @@ input:autofill:disabled {
         --chart-5: 27 87% 67%;
         --radius: 0.5rem;
     }
-  .dark {
+    .dark {
         --background: 224 71.4% 4.1%;
         --foreground: 210 20% 98%;
         --card: 224 71.4% 4.1%;
@@ -118,10 +118,10 @@ input:autofill:disabled {
 }
 
 @layer base {
-  * {
-    @apply border-border;
+    * {
+        @apply border-border;
     }
-  body {
-    @apply bg-background text-foreground;
+    body {
+        @apply bg-background text-foreground;
     }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,8 +2,6 @@ export default function Home() {
     return (
         <div>
             <div>Home 페이지</div>
-            <div>Home 페이지</div>
-            <div>Home 페이지</div>
         </div>
     )
 }

--- a/src/app/quizbook/(no-layout)/post/@modal/add/_components/AddQuizForm/AnswerInput.tsx
+++ b/src/app/quizbook/(no-layout)/post/@modal/add/_components/AddQuizForm/AnswerInput.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { QUIZ_TYPE } from '@/constants/quiz'
+import { useWatch } from 'react-hook-form'
+import {
+    LongAnswerInput,
+    MultipleAnswerInput,
+    OXAnswerInput,
+    ShortAnswerInput,
+} from './quiz-answer'
+
+export default function AnswerInput() {
+    const type = useWatch({ name: 'type' })
+
+    switch (type) {
+        case QUIZ_TYPE.OX:
+            return <OXAnswerInput />
+        case QUIZ_TYPE.MULTIPLE:
+            return <MultipleAnswerInput />
+        case QUIZ_TYPE.SHORT:
+            return <ShortAnswerInput />
+        case QUIZ_TYPE.LONG:
+            return <LongAnswerInput />
+        default:
+            return null
+    }
+}

--- a/src/app/quizbook/(no-layout)/post/@modal/add/_components/AddQuizForm/index.tsx
+++ b/src/app/quizbook/(no-layout)/post/@modal/add/_components/AddQuizForm/index.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { CustomSelect } from '@/components'
+import { QUIZ_TYPE } from '@/constants/quiz'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { FormProvider, useForm, useWatch } from 'react-hook-form'
+import { CustomInput } from '@/components'
+import AnswerInput from './AnswerInput'
+import { useEffect } from 'react'
+import { AddQuizFormValues, addQuizSchema } from '../../../../_schema/add-quiz'
+import { usePostQuizbookStore } from '@/store/quizbook'
+import { useRouter } from 'next/navigation'
+
+export default function AddQuizForm() {
+    const { addQuiz } = usePostQuizbookStore()
+    const router = useRouter()
+
+    const methods = useForm<AddQuizFormValues>({
+        resolver: zodResolver(addQuizSchema),
+        defaultValues: {
+            type: QUIZ_TYPE.OX,
+        },
+        mode: 'onChange',
+    })
+    const { handleSubmit, setValue, unregister, control } = methods
+    const type = useWatch({ control, name: 'type' })
+
+    const onSubmit = (data: AddQuizFormValues) => {
+        addQuiz(data)
+        router.back()
+    }
+
+    useEffect(() => {
+        if (type === QUIZ_TYPE.MULTIPLE) {
+            setValue('optionList', ['', '', '', ''])
+            setValue('answer', '')
+        } else unregister('optionList')
+    }, [type, setValue, unregister])
+
+    return (
+        <FormProvider {...methods}>
+            <form
+                className="flex flex-col gap-[16px]"
+                onSubmit={handleSubmit(onSubmit)}
+            >
+                {/* 유형 영역 */}
+                <CustomSelect
+                    id="type"
+                    name="type"
+                    label="유형"
+                    placeholder="유형 선택"
+                >
+                    {Object.entries(QUIZ_TYPE).map(([key, value]) => (
+                        <CustomSelect.Item key={key} value={value}>
+                            {value}
+                        </CustomSelect.Item>
+                    ))}
+                </CustomSelect>
+
+                {/* 질문 영역 */}
+                <CustomInput
+                    id="question"
+                    name="question"
+                    label="질문"
+                    area={true}
+                    placeholder="질문을 입력해주세요."
+                />
+
+                {/* 답안 영역 */}
+                <AnswerInput />
+
+                {/* 버튼 영역 */}
+                <button className="btn-solid btn-mobile-lg w-full md:btn-pc-lg">
+                    추가하기
+                </button>
+            </form>
+        </FormProvider>
+    )
+}

--- a/src/app/quizbook/(no-layout)/post/@modal/add/_components/AddQuizForm/quiz-answer/LongAnswerInput.tsx
+++ b/src/app/quizbook/(no-layout)/post/@modal/add/_components/AddQuizForm/quiz-answer/LongAnswerInput.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { CustomInput } from '@/components'
+
+export default function LongAnswerInput() {
+    return (
+        <CustomInput
+            id="answer"
+            name="answer"
+            label="답안"
+            area={true}
+            placeholder="답안을 입력해주세요."
+        />
+    )
+}

--- a/src/app/quizbook/(no-layout)/post/@modal/add/_components/AddQuizForm/quiz-answer/MultipleAnswerInput.tsx
+++ b/src/app/quizbook/(no-layout)/post/@modal/add/_components/AddQuizForm/quiz-answer/MultipleAnswerInput.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { CustomInput } from '@/components'
+import { CustomSelect } from '@/components'
+import { useFieldArray, useFormContext } from 'react-hook-form'
+
+export default function MultipleAnswerInput() {
+    const { control, watch } = useFormContext()
+    const { fields } = useFieldArray({ control, name: 'optionList' })
+
+    return (
+        <>
+            {/* 선택지 영역 */}
+            <fieldset className="mb-[12px]">
+                <legend className="mb-[4px] text-mobile-body-sm font-regular text-gray-500 md:text-pc-body-sm">
+                    선택지
+                </legend>
+                <div className="flex flex-col items-center justify-center gap-[4px] rounded-md border-2 border-gray-200 px-[8px] pb-[16px] pt-[28px] md:px-[16px]">
+                    {fields.map((field, idx) => (
+                        <CustomInput
+                            key={field.id}
+                            id={`optionList.${idx}`}
+                            name={`optionList.${idx}`}
+                            placeholder={`선택지 ${idx + 1}`}
+                        />
+                    ))}
+                </div>
+            </fieldset>
+
+            {/* 답안 영역 */}
+            <CustomSelect
+                id="answer"
+                name="answer"
+                placeholder="정답을 선택해주세요."
+                label="정답"
+            >
+                {fields.map((field, idx) => {
+                    const option = watch(`optionList.${idx}`)
+
+                    if (!option) return null
+
+                    return (
+                        <CustomSelect.Item key={field.id} value={option}>
+                            선택지 {idx + 1}
+                        </CustomSelect.Item>
+                    )
+                })}
+            </CustomSelect>
+        </>
+    )
+}

--- a/src/app/quizbook/(no-layout)/post/@modal/add/_components/AddQuizForm/quiz-answer/MultipleAnswerInput.tsx
+++ b/src/app/quizbook/(no-layout)/post/@modal/add/_components/AddQuizForm/quiz-answer/MultipleAnswerInput.tsx
@@ -8,6 +8,9 @@ export default function MultipleAnswerInput() {
     const { control, watch } = useFormContext()
     const { fields } = useFieldArray({ control, name: 'optionList' })
 
+    // select 중복 방지 변수
+    const rendered = new Set<string>()
+
     return (
         <>
             {/* 선택지 영역 */}
@@ -36,11 +39,14 @@ export default function MultipleAnswerInput() {
             >
                 {fields.map((field, idx) => {
                     const option = watch(`optionList.${idx}`)
-
-                    if (!option) return null
+                    if (!option || rendered.has(option)) return null
+                    rendered.add(option)
 
                     return (
-                        <CustomSelect.Item key={field.id} value={option}>
+                        <CustomSelect.Item
+                            key={`${field.id}-${option}`}
+                            value={option}
+                        >
                             선택지 {idx + 1}
                         </CustomSelect.Item>
                     )

--- a/src/app/quizbook/(no-layout)/post/@modal/add/_components/AddQuizForm/quiz-answer/OXAnswerInput.tsx
+++ b/src/app/quizbook/(no-layout)/post/@modal/add/_components/AddQuizForm/quiz-answer/OXAnswerInput.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import CustomSelect from '@/components/CustomSelect'
+
+export default function OXAnswerInput() {
+    return (
+        <CustomSelect
+            id="answer"
+            name="answer"
+            placeholder="정답을 선택해주세요."
+            label="정답"
+        >
+            <CustomSelect.Item value="O">O</CustomSelect.Item>
+            <CustomSelect.Item value="X">X</CustomSelect.Item>
+        </CustomSelect>
+    )
+}

--- a/src/app/quizbook/(no-layout)/post/@modal/add/_components/AddQuizForm/quiz-answer/ShortAnswerInput.tsx
+++ b/src/app/quizbook/(no-layout)/post/@modal/add/_components/AddQuizForm/quiz-answer/ShortAnswerInput.tsx
@@ -1,0 +1,12 @@
+import { CustomInput } from '@/components'
+
+export default function ShortAnswerInput() {
+    return (
+        <CustomInput
+            id="answer"
+            name="answer"
+            placeholder="정답을 입력해주세요."
+            label="정답"
+        />
+    )
+}

--- a/src/app/quizbook/(no-layout)/post/@modal/add/_components/AddQuizForm/quiz-answer/index.tsx
+++ b/src/app/quizbook/(no-layout)/post/@modal/add/_components/AddQuizForm/quiz-answer/index.tsx
@@ -1,0 +1,4 @@
+export { default as OXAnswerInput } from './OXAnswerInput'
+export { default as MultipleAnswerInput } from './MultipleAnswerInput'
+export { default as ShortAnswerInput } from './ShortAnswerInput'
+export { default as LongAnswerInput } from './LongAnswerInput'

--- a/src/app/quizbook/(no-layout)/post/@modal/add/_components/index.ts
+++ b/src/app/quizbook/(no-layout)/post/@modal/add/_components/index.ts
@@ -1,0 +1,1 @@
+export { default as AddQuizForm } from './AddQuizForm'

--- a/src/app/quizbook/(no-layout)/post/@modal/add/page.tsx
+++ b/src/app/quizbook/(no-layout)/post/@modal/add/page.tsx
@@ -1,0 +1,10 @@
+import { Modal } from '@/components'
+import { AddQuizForm } from './_components'
+
+export default function Page() {
+    return (
+        <Modal title="퀴즈 추가" closeOnOverlayClick={true}>
+            <AddQuizForm />
+        </Modal>
+    )
+}

--- a/src/app/quizbook/(no-layout)/post/@modal/default.tsx
+++ b/src/app/quizbook/(no-layout)/post/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function AddModalDefault() {
+    return null
+}

--- a/src/app/quizbook/(no-layout)/post/_components/PostQuizbookForm/AddedQuiz.tsx
+++ b/src/app/quizbook/(no-layout)/post/_components/PostQuizbookForm/AddedQuiz.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import CloseSvg from '@/assets/svgs/close.svg'
+
+import { Quiz } from '@/types/quiz'
+import AddedQuizField from './AddedQuizField'
+import { QUIZ_TYPE } from '@/constants/quiz'
+import { usePostQuizbookStore } from '@/store/quizbook'
+
+interface Props {
+    quiz: Quiz
+    idx: number
+}
+
+export default function AddedQuiz({ quiz, idx }: Props) {
+    const { removeQuiz } = usePostQuizbookStore()
+
+    const onClickCloseBtn = (e: React.MouseEvent<HTMLButtonElement>) => {
+        e.preventDefault()
+        removeQuiz(idx)
+    }
+
+    return (
+        <div className="flex flex-col rounded-lg bg-white p-[16px] md:bg-point-50 md:px-[32px]">
+            {/* 카드 타이틀 및 닫기 버튼 */}
+            <div className="flex justify-end pl-[15px] md:pl-[20px]">
+                <span className="flex-1 text-center text-mobile-body-lg font-semi-bold text-gray-900 md:text-pc-body-lg">
+                    {idx + 1}번 문제
+                </span>
+                <button
+                    onClick={onClickCloseBtn}
+                    className="text-gray-900 hover:text-point-500 active:text-point-500"
+                >
+                    <CloseSvg className="h-[15px] w-[15px] md:h-[20px] md:w-[20px]" />
+                </button>
+            </div>
+
+            {/* 카드 영역 */}
+            <div className="flex flex-col gap-[8px]">
+                <AddedQuizField label="질문">{quiz.question}</AddedQuizField>
+                {quiz.type !== QUIZ_TYPE.MULTIPLE && (
+                    <AddedQuizField
+                        label="정답"
+                        area={quiz.type === QUIZ_TYPE.LONG}
+                    >
+                        {quiz.answer}
+                    </AddedQuizField>
+                )}
+                {quiz.optionList && (
+                    <AddedQuizField label="정답">
+                        {quiz.optionList.map((option, idx) => (
+                            <AddedQuizField
+                                key={`option-${idx}`}
+                                className={
+                                    option === quiz.answer
+                                        ? 'border-point-500'
+                                        : undefined
+                                }
+                            >
+                                {option}
+                            </AddedQuizField>
+                        ))}
+                    </AddedQuizField>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/src/app/quizbook/(no-layout)/post/_components/PostQuizbookForm/AddedQuizField.tsx
+++ b/src/app/quizbook/(no-layout)/post/_components/PostQuizbookForm/AddedQuizField.tsx
@@ -1,0 +1,34 @@
+import clsx from 'clsx'
+
+interface Props {
+    className?: string
+    children: React.ReactNode
+    label?: string
+    area?: boolean
+}
+
+export default function AddedQuizField({
+    label,
+    children,
+    area = false,
+    className = '',
+}: Props) {
+    return (
+        <div className="flex w-full flex-col items-start gap-1">
+            {label && (
+                <span className="text-mobile-body-sm font-regular text-gray-500 md:text-pc-body-sm">
+                    {label}
+                </span>
+            )}
+            <div
+                className={clsx(
+                    'w-full rounded-lg border-2 border-gray-200 bg-white px-6 py-3 text-mobile-body-md font-regular text-gray-900 md:text-pc-body-md',
+                    area && 'custom-scrollbar min-h-[120px]',
+                    className,
+                )}
+            >
+                {children}
+            </div>
+        </div>
+    )
+}

--- a/src/app/quizbook/(no-layout)/post/_components/PostQuizbookForm/index.tsx
+++ b/src/app/quizbook/(no-layout)/post/_components/PostQuizbookForm/index.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import PlusSvg from '@/assets/svgs/plus.svg'
+
+import { usePostQuizbookStore } from '@/store/quizbook'
+import { FormProvider, useForm } from 'react-hook-form'
+import {
+    PostQuizbookFormValues,
+    postQuizbookSchema,
+} from '../../_schema/post-quizbook'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { CustomInput, CustomSelect } from '@/components'
+import { QUIZBOOK_CATEGORY } from '@/constants/quizbook'
+import AddedQuiz from './AddedQuiz'
+import Link from 'next/link'
+import { useEffect } from 'react'
+
+export default function PostQuizbookForm() {
+    const methods = useForm<PostQuizbookFormValues>({
+        resolver: zodResolver(postQuizbookSchema),
+        mode: 'onChange',
+        defaultValues: {
+            title: '',
+            category: undefined,
+            quizList: [],
+        },
+    })
+
+    const { handleSubmit, setValue, reset } = methods
+
+    const { quizList, resetQuizList } = usePostQuizbookStore()
+
+    const onSubmit = (data: PostQuizbookFormValues) => {
+        // TODO: API 연동 로직 및 페이지 이동
+        console.log(data)
+
+        resetQuizList()
+        reset()
+    }
+
+    // TODO: AUTO SAVE 기능 추가
+
+    useEffect(() => {
+        setValue('quizList', quizList)
+    }, [quizList, setValue])
+
+    return (
+        <FormProvider {...methods}>
+            <form
+                id="post-quizbook-form"
+                className="flex min-h-0 flex-1 flex-col gap-[8px]"
+                onSubmit={handleSubmit(onSubmit)}
+            >
+                {/* 카테고리 영역 */}
+                <CustomSelect
+                    id="category"
+                    name="category"
+                    label="카테고리"
+                    placeholder="카테고리 선택"
+                    className="bg-white"
+                >
+                    {Object.entries(QUIZBOOK_CATEGORY).map(([key, value]) => (
+                        <CustomSelect.Item key={key} value={value}>
+                            {value}
+                        </CustomSelect.Item>
+                    ))}
+                </CustomSelect>
+
+                {/* 제목 영역 */}
+                <CustomInput
+                    id="title"
+                    name="title"
+                    label="제목"
+                    placeholder="제목을 입력해주세요."
+                />
+
+                {/* 추가 카드 리스트 영역 */}
+                <div className="flex w-full flex-1 flex-col gap-1 overflow-hidden">
+                    <span className="text-mobile-body-sm font-regular text-gray-500 md:text-pc-body-sm">
+                        {`추가된 문제(총 ${quizList.length})`}
+                    </span>
+                    <div className="custom-scrollbar flex w-full flex-1 flex-col gap-[8px] overflow-y-auto px-[8px] pl-0 md:px-[16px] md:pl-0">
+                        {quizList.map((quiz, idx) => (
+                            <AddedQuiz
+                                key={`${quiz}-${idx}`}
+                                quiz={quiz}
+                                idx={idx}
+                            />
+                        ))}
+                    </div>
+                </div>
+            </form>
+
+            {/* 버튼 영역 */}
+            <div className="flex flex-col gap-[8px]">
+                <Link
+                    className="btn-outline btn-mobile-lg flex w-full items-center justify-center md:btn-pc-lg"
+                    href={'/quizbook/post/add'}
+                >
+                    <PlusSvg className="h-[24px] w-[24px]" />
+                </Link>
+                <button
+                    type="submit"
+                    form="post-quizbook-form"
+                    className="btn-solid btn-mobile-lg w-full md:btn-pc-lg"
+                >
+                    생성하기
+                </button>
+            </div>
+        </FormProvider>
+    )
+}

--- a/src/app/quizbook/(no-layout)/post/_components/index.ts
+++ b/src/app/quizbook/(no-layout)/post/_components/index.ts
@@ -1,0 +1,1 @@
+export { default as PostQuizbookForm } from './PostQuizbookForm'

--- a/src/app/quizbook/(no-layout)/post/_schema/add-quiz.ts
+++ b/src/app/quizbook/(no-layout)/post/_schema/add-quiz.ts
@@ -1,0 +1,49 @@
+import { QUIZ_TYPE } from '@/constants/quiz'
+import * as z from 'zod'
+
+const baseSchema = z.object({
+    type: z.enum(
+        [QUIZ_TYPE.OX, QUIZ_TYPE.MULTIPLE, QUIZ_TYPE.SHORT, QUIZ_TYPE.LONG],
+        {
+            errorMap: () => ({ message: '유형을 선택해주세요.' }),
+        },
+    ),
+    question: z.string().min(1, '질문을 입력해주세요.'),
+})
+
+const oxSchema = baseSchema.extend({
+    type: z.literal(QUIZ_TYPE.OX),
+    answer: z.enum(['O', 'X'], {
+        errorMap: () => ({ message: '정답을 선택해주세요.' }),
+    }),
+})
+
+const multipleSchema = baseSchema.extend({
+    type: z.literal(QUIZ_TYPE.MULTIPLE),
+    optionList: z
+        .array(z.string().min(1, '빈 선택지는 허용되지 않습니다.'))
+        .length(4, '4개의 선택지를 입력해주세요.')
+        .refine((list) => new Set(list).size === list.length, {
+            message: '선택지는 중복될 수 없습니다.',
+        }),
+    answer: z.string().min(1, '정답을 선택해주세요.'),
+})
+
+const shortSchema = baseSchema.extend({
+    type: z.literal(QUIZ_TYPE.SHORT),
+    answer: z.string().min(1, '정답을 입력해주세요.'),
+})
+
+const longSchema = baseSchema.extend({
+    type: z.literal(QUIZ_TYPE.LONG),
+    answer: z.string().min(1, '답안을 입력해주세요.'),
+})
+
+export const addQuizSchema = z.discriminatedUnion('type', [
+    oxSchema,
+    multipleSchema,
+    shortSchema,
+    longSchema,
+])
+
+export type AddQuizFormValues = z.infer<typeof addQuizSchema>

--- a/src/app/quizbook/(no-layout)/post/_schema/post-quizbook.ts
+++ b/src/app/quizbook/(no-layout)/post/_schema/post-quizbook.ts
@@ -1,0 +1,21 @@
+import { QUIZBOOK_CATEGORY } from '@/constants/quizbook'
+import * as z from 'zod'
+import { addQuizSchema } from './add-quiz'
+
+export type PostQuizbookFormValues = z.infer<typeof postQuizbookSchema>
+
+export const postQuizbookSchema = z.object({
+    title: z.string().min(1, '제목을 입력해주세요.'),
+    category: z.enum(
+        [
+            QUIZBOOK_CATEGORY.DATA_STRUCTURE,
+            QUIZBOOK_CATEGORY.ALGORITHM,
+            QUIZBOOK_CATEGORY.DATABASE,
+            QUIZBOOK_CATEGORY.NETWORK,
+            QUIZBOOK_CATEGORY.WEB,
+            QUIZBOOK_CATEGORY.ETC,
+        ],
+        { errorMap: () => ({ message: '카테고리를 선택해주세요.' }) },
+    ),
+    quizList: z.array(addQuizSchema).min(1, '퀴즈를 1개 이상 추가해주세요.'),
+})

--- a/src/app/quizbook/(no-layout)/post/layout.tsx
+++ b/src/app/quizbook/(no-layout)/post/layout.tsx
@@ -1,7 +1,31 @@
+import DesktopHeader from '@/components/DesktopHeader'
+import MobileHeader from '@/components/MobileHeader'
+
 interface Props {
     children: React.ReactNode
+    modal: React.ReactNode
 }
 
-export default function Layout({ children }: Props) {
-    return <main>{children}</main>
+export default function Layout({ children, modal }: Props) {
+    return (
+        <div className="flex max-h-screen min-h-screen flex-col">
+            {/* 모달 */}
+            {modal}
+
+            {/* 헤더 */}
+            <DesktopHeader>
+                <nav className="flex">
+                    <DesktopHeader.MenuItem text="문제집" href="/quizbook" />
+                    <DesktopHeader.MenuItem text="그룹" href="/group" />
+                </nav>
+                <DesktopHeader.UserMenu />
+            </DesktopHeader>
+            <MobileHeader title="문제집 생성" backBtn={true} />
+
+            {/* 컨텐츠 */}
+            <main className="flex min-h-0 flex-1 flex-col items-center p-[16px]">
+                {children}
+            </main>
+        </div>
+    )
 }

--- a/src/app/quizbook/(no-layout)/post/page.tsx
+++ b/src/app/quizbook/(no-layout)/post/page.tsx
@@ -2,7 +2,7 @@ import { PostQuizbookForm } from './_components'
 
 export default function Page() {
     return (
-        <div className="flex min-h-0 w-full max-w-[768px] flex-1 flex-col gap-[16px] overflow-hidden md:gap-[32px] md:rounded-lg md:bg-white md:p-[16px] md:p-[32px] md:shadow-point">
+        <div className="flex min-h-0 w-full max-w-[768px] flex-1 flex-col gap-[16px] overflow-hidden md:gap-[32px] md:rounded-lg md:bg-white md:p-[32px] md:shadow-point">
             {/* Desktop 제목 영역 */}
             <h2 className="hidden text-center font-extra-bold text-point-900 md:block md:text-pc-title-sm">
                 문제집 생성

--- a/src/app/quizbook/(no-layout)/post/page.tsx
+++ b/src/app/quizbook/(no-layout)/post/page.tsx
@@ -1,3 +1,15 @@
+import { PostQuizbookForm } from './_components'
+
 export default function Page() {
-    return <div>문제집 등록 페이지</div>
+    return (
+        <div className="flex min-h-0 w-full max-w-[768px] flex-1 flex-col gap-[16px] overflow-hidden md:gap-[32px] md:rounded-lg md:bg-white md:p-[16px] md:p-[32px] md:shadow-point">
+            {/* Desktop 제목 영역 */}
+            <h2 className="hidden text-center font-extra-bold text-point-900 md:block md:text-pc-title-sm">
+                문제집 생성
+            </h2>
+
+            {/* Form 영역 */}
+            <PostQuizbookForm />
+        </div>
+    )
 }

--- a/src/components/CustomSelect/CustomSelectRoot.tsx
+++ b/src/components/CustomSelect/CustomSelectRoot.tsx
@@ -50,7 +50,7 @@ export default function CustomSelectRoot({
                 name={name}
                 render={({ field: { value, onChange } }) => (
                     <Select
-                        value={value}
+                        value={value ?? ''}
                         onValueChange={onChange}
                         disabled={disabled}
                         open={isOpen}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -11,13 +11,15 @@ interface ModalProps {
     children?: React.ReactNode
     closeOnOverlayClick?: boolean // 배경 클릭으로 닫기 여부 제어
     className?: string
+    isFullWith?: boolean
 }
 
 export default function Modal({
     title,
     children,
-    closeOnOverlayClick = false, // 기본값은 false로 설정 (= 배경 클릭으로 닫기 비활성화)
+    closeOnOverlayClick = true, // 기본값은 true로 설정 (= 배경 클릭으로 닫기 비활성화)
     className = '',
+    isFullWith = true,
 }: ModalProps) {
     const router = useRouter()
 
@@ -46,12 +48,15 @@ export default function Modal({
 
     return (
         <div
-            className="absolute inset-0 flex min-h-screen w-full flex-col items-center justify-center bg-gray-900 bg-opacity-70 px-[16px] backdrop-blur-sm md:px-[32px]"
+            className="absolute inset-0 flex min-h-screen w-full flex-col items-center justify-center bg-gray-900 bg-opacity-70 p-[16px] backdrop-blur-sm md:p-[32px]"
             onClick={handleOverlayClick}
         >
             {/* 모달 컨텐츠 영역 */}
             <div
-                className="flex max-h-[70vh] w-full max-w-[768px] flex-col gap-[16px] overflow-hidden rounded-lg bg-white py-[16px]"
+                className={clsx(
+                    'flex max-w-[768px] flex-col gap-[16px] overflow-hidden rounded-lg bg-white py-[16px] md:py-[32px]',
+                    isFullWith ? 'w-full' : '',
+                )}
                 role="dialog"
                 aria-modal="true"
                 aria-labelledby={title ? 'modal-title' : undefined}
@@ -77,7 +82,7 @@ export default function Modal({
 
                 <div
                     className={clsx(
-                        'custom-scrollbar flex-1 grow overflow-y-auto px-[16px] md:px-[32px]',
+                        'md:custom-scrollbar flex-1 grow overflow-y-auto px-[16px] md:px-[32px]',
                         className,
                     )}
                 >

--- a/src/components/study/ScoreTag.tsx
+++ b/src/components/study/ScoreTag.tsx
@@ -1,12 +1,12 @@
 import clsx from 'clsx'
 import { TypeToColor, TypeToXp } from '@/constants/quiz'
-import { QuestionType } from '@/types/quiz'
+import { QuizType } from '@/types/quiz'
 
 // SVG
 import PlusSvg from '@/assets/svgs/plus.svg'
 
 interface ScoreTagProps {
-    type: QuestionType
+    type: QuizType
 }
 
 export default function ScoreTag({ type }: ScoreTagProps) {

--- a/src/constants/quiz.ts
+++ b/src/constants/quiz.ts
@@ -1,7 +1,7 @@
-import { QuestionType } from '@/types/quiz'
+import { QuizType } from '@/types/quiz'
 
 // 문제 유형
-export const QUESTION_TYPE = {
+export const QUIZ_TYPE = {
     OX: 'ox',
     MULTIPLE: '객관식',
     SHORT: '주관식',
@@ -9,7 +9,7 @@ export const QUESTION_TYPE = {
 } as const
 
 // 문제 유형별 경험치
-export const TypeToXp: Record<QuestionType, number> = {
+export const TypeToXp: Record<QuizType, number> = {
     ox: 5,
     객관식: 10,
     주관식: 15,
@@ -17,7 +17,7 @@ export const TypeToXp: Record<QuestionType, number> = {
 }
 
 // 문제 유형별 컬러
-export const TypeToColor: Record<QuestionType, string> = {
+export const TypeToColor: Record<QuizType, string> = {
     ox: 'text-[#4CAF50]',
     객관식: 'text-[#2196F3]',
     주관식: 'text-[#8A43EF]',

--- a/src/constants/quizbook.ts
+++ b/src/constants/quizbook.ts
@@ -1,0 +1,8 @@
+export const QUIZBOOK_CATEGORY = {
+    DATA_STRUCTURE: '자료구조',
+    ALGORITHM: '알고리즘',
+    NETWORK: '네트워크',
+    DATABASE: '데이터베이스',
+    WEB: '웹 개발',
+    ETC: '기타',
+} as const

--- a/src/store/quizbook/index.ts
+++ b/src/store/quizbook/index.ts
@@ -1,0 +1,1 @@
+export { default as usePostQuizbookStore } from './usePostQuizbookStore'

--- a/src/store/quizbook/usePostQuizbookStore.ts
+++ b/src/store/quizbook/usePostQuizbookStore.ts
@@ -1,0 +1,22 @@
+import { Quiz } from '@/types/quiz'
+import { create } from 'zustand'
+
+interface PostQuizbookStore {
+    quizList: Quiz[]
+    addQuiz: (quiz: Quiz) => void
+    removeQuiz: (idx: number) => void
+    resetQuizList: () => void
+}
+
+const usePostQuizbookStore = create<PostQuizbookStore>((set) => ({
+    quizList: [],
+    addQuiz: (quiz) =>
+        set((state) => ({ quizList: [...state.quizList, quiz] })),
+    removeQuiz: (idx) =>
+        set((state) => ({
+            quizList: state.quizList.filter((_, i) => i !== idx),
+        })),
+    resetQuizList: () => set({ quizList: [] }),
+}))
+
+export default usePostQuizbookStore

--- a/src/types/quiz.d.ts
+++ b/src/types/quiz.d.ts
@@ -1,4 +1,12 @@
-import { QUESTION_TYPE } from '@/constants/quiz'
+import { QUIZ_TYPE } from '@/constants/quiz'
 
-// Quiz > question 필드 타입
-export type QuestionType = (typeof QUESTION_TYPE)[keyof typeof QUESTION_TYPE]
+// Quiz > type 필드 타입
+export type QuizType = (typeof QUESTION_TYPE)[keyof typeof QUESTION_TYPE]
+
+// Quiz 타입
+export interface Quiz {
+    type: QuizType
+    question: string
+    answer: string
+    optionList?: string[]
+}

--- a/src/types/quiz.d.ts
+++ b/src/types/quiz.d.ts
@@ -1,12 +1,16 @@
 import { QUIZ_TYPE } from '@/constants/quiz'
 
 // Quiz > type 필드 타입
-export type QuizType = (typeof QUESTION_TYPE)[keyof typeof QUESTION_TYPE]
+export type QuizType = (typeof QUIZ_TYPE)[keyof typeof QUIZ_TYPE]
 
 // Quiz 타입
-export interface Quiz {
-    type: QuizType
-    question: string
-    answer: string
-    optionList?: string[]
-}
+export type Quiz =
+    | { type: typeof QUIZ_TYPE.OX; question: string; answer: 'O' | 'X' }
+    | {
+          type: typeof QUIZ_TYPE.MULTIPLE
+          question: string
+          answer: string
+          optionList: string[]
+      }
+    | { type: typeof QUIZ_TYPE.SHORT; question: string; answer: string }
+    | { type: typeof QUIZ_TYPE.LONG; question: string; answer: string }

--- a/src/types/quizbook.d.ts
+++ b/src/types/quizbook.d.ts
@@ -1,8 +1,13 @@
+import { QUIZBOOK_CATEGORY } from '@/constants/quizbook'
+
+export type QuizbookCategoryType =
+    (typeof QUIZBOOK_CATEGORY)[keyof typeof QUIZBOOK_CATEGORY]
+
 export interface Quizbook<T = unknown> {
     _id: string
     title: string
     description: string
-    category: string
+    category: QuizbookCategoryType
     solvedCount: number
     solvedRate: number
     reviewCount: number


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
- 문제집 생성 페이지 구현
- Quiz 추가 모달 구현
- 모달 컴포넌트 소폭 수정

## 📌 이슈 넘버
> #14 

## 📝 작업 내용
- 문제집 생성 페이지 구현
- Quiz 추가 모달 구현 ( OX | 객관식 | 주관식 | 서술형 )
- 모달 컴포넌트 소폭 수정
  - 70vh 높이 고정 => 컨텐츠 크기
  - 외부 패딩 x,y 동일하게 적용 `p-[16px]`, `md: p-[32px]`
  - 화면 크기 `sm`인 경우 `custom-scrollbar 제거`
  - `isFullWidth` Props 추가 ( 내부 컨텐츠 영역이 w-full이 필요 없는 크기인 경우 사용 )

## 📸 스크린샷
![GIF 2025-04-24 오전 1-10-07](https://github.com/user-attachments/assets/ef73529a-16cc-41e8-8c86-90291847cf48)