### PR TITLE
[FEAT] 문제집 상세 페이지 병렬 라우트 모달 퍼블리싱

### DIFF
--- a/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/@main/page.tsx
+++ b/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/@main/page.tsx
@@ -6,11 +6,17 @@ import NoteIcon from '@/assets/svgs/note.svg'
 import DateIcon from '@/assets/svgs/date.svg'
 import Link from 'next/link'
 import { ProfileImage } from '@/components'
-import Preview from './_components/Preview'
-import Review from './_components/Review'
-import SideBar from './_components/SideBar'
+import Preview from '../_components/Preview'
+import Review from '../_components/Review'
+import SideBar from '../_components/SideBar'
 
-export default function Page() {
+export default async function QuizbookDetailPage({
+    params,
+}: {
+    params: Promise<{ quizbookId: string }>
+}) {
+    const { quizbookId } = await params
+
     return (
         <main className="no-scrollbar flex w-full flex-1 flex-col items-center overflow-auto">
             <section className="relative flex w-full justify-center">
@@ -70,7 +76,7 @@ export default function Page() {
             <div className="flex w-full max-w-[1056px] items-start">
                 <div className="flex flex-1 flex-col gap-8 p-4 md:py-8">
                     <Preview />
-                    <Review />
+                    <Review quizbookId={quizbookId} />
                 </div>
                 <div className="relative hidden h-full p-4 md:block md:py-8">
                     <SideBar />

--- a/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/@modal/[modalType]/[reviewId]/_components/DeleteReviewModal.tsx
+++ b/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/@modal/[modalType]/[reviewId]/_components/DeleteReviewModal.tsx
@@ -1,0 +1,40 @@
+'use client'
+
+import { LoopAnimation, Modal } from '@/components'
+import clsx from 'clsx'
+import { useState } from 'react'
+
+export default function DeleteReviewModal() {
+    const [isLoading, setIsLoading] = useState(false)
+
+    const handleClick = () => {
+        // 추후 로직 수정
+        setIsLoading(true)
+        setTimeout(() => {
+            console.log(1)
+            setIsLoading(false)
+        }, 2000)
+    }
+
+    return (
+        <Modal title="후기 삭제" closeOnOverlayClick={true} isFullWith={false}>
+            <div className="flex flex-col items-center gap-4">
+                <div className="flex w-full flex-col items-center gap-2 rounded-lg border-2 border-gray-200 bg-point-50 p-4 text-mobile-body-md font-semi-bold text-gray-500 md:p-8 md:text-pc-body-md">
+                    <span>정말로, 소중하신 후기를</span>
+                    <span>삭제하시겠습니까?</span>
+                </div>
+                <button
+                    disabled={isLoading}
+                    className={clsx(
+                        'btn-solid btn-mobile-md bg-danger-300 md:btn-pc-md',
+                        isLoading && 'btn-loading',
+                    )}
+                    onClick={handleClick}
+                >
+                    {isLoading && <LoopAnimation />}
+                    {isLoading ? 'Loading...' : '삭제'}
+                </button>
+            </div>
+        </Modal>
+    )
+}

--- a/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/@modal/[modalType]/[reviewId]/_components/EditReviewModal.tsx
+++ b/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/@modal/[modalType]/[reviewId]/_components/EditReviewModal.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import * as z from 'zod'
+import { CustomInput, LoopAnimation, Modal } from '@/components'
+import { useState } from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import clsx from 'clsx'
+import StarScore from '../../_components/StarScore'
+import { useParams } from 'next/navigation'
+
+const schema = z.object({
+    content: z.string().max(50, { message: '리뷰는 50자 이하로 해주세요' }),
+})
+
+type FormData = z.infer<typeof schema>
+
+export default function EditReviewModal() {
+    const [isLoading, setIsLoading] = useState(false)
+    const [score, setScore] = useState(5)
+    const params = useParams()
+
+    const methods = useForm<FormData>({
+        resolver: zodResolver(schema),
+        mode: 'onChange',
+    })
+
+    const handleFormSubmit = async (data: FormData) => {
+        // 추후 로직 수정
+        setIsLoading(true)
+        setTimeout(() => {
+            console.log('Form Data:', { ...data, score })
+            setIsLoading(false)
+        }, 2000)
+    }
+
+    return (
+        <Modal title="후기 수정" closeOnOverlayClick={true}>
+            <FormProvider {...methods}>
+                <form
+                    onSubmit={methods.handleSubmit(handleFormSubmit)}
+                    className="flex flex-col items-center gap-4"
+                >
+                    <StarScore score={score} setScore={setScore} />
+                    <CustomInput
+                        id="content"
+                        name="content"
+                        area={true}
+                        placeholder="수정된 후기를 작성해주세요!"
+                        disabled={isLoading}
+                    />
+                    <div className="flex w-full justify-end">
+                        <button
+                            type="submit"
+                            disabled={isLoading}
+                            className={clsx(
+                                'btn-solid btn-mobile-lg md:btn-pc-lg',
+                                isLoading && 'btn-loading',
+                            )}
+                        >
+                            {isLoading && <LoopAnimation />}
+                            {isLoading ? 'Loading...' : '수정'}
+                        </button>
+                    </div>
+                </form>
+            </FormProvider>
+        </Modal>
+    )
+}

--- a/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/@modal/[modalType]/[reviewId]/page.tsx
+++ b/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/@modal/[modalType]/[reviewId]/page.tsx
@@ -1,0 +1,18 @@
+import EditReviewModal from './_components/EditReviewModal'
+
+export default async function ModalWithIdWrapper({
+    params,
+}: {
+    params: Promise<{ modalType: string }>
+}) {
+    const { modalType } = await params
+
+    switch (modalType) {
+        case 'edit-review':
+            return <EditReviewModal />
+        // case 'delete-review':
+        //     return <DeleteReviewModal />
+        default:
+            return null
+    }
+}

--- a/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/@modal/[modalType]/[reviewId]/page.tsx
+++ b/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/@modal/[modalType]/[reviewId]/page.tsx
@@ -1,3 +1,4 @@
+import DeleteReviewModal from './_components/DeleteReviewModal'
 import EditReviewModal from './_components/EditReviewModal'
 
 export default async function ModalWithIdWrapper({
@@ -10,8 +11,8 @@ export default async function ModalWithIdWrapper({
     switch (modalType) {
         case 'edit-review':
             return <EditReviewModal />
-        // case 'delete-review':
-        //     return <DeleteReviewModal />
+        case 'delete-review':
+            return <DeleteReviewModal />
         default:
             return null
     }

--- a/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/@modal/[modalType]/_components/CreateReviewModal.tsx
+++ b/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/@modal/[modalType]/_components/CreateReviewModal.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import * as z from 'zod'
+import { CustomInput, LoopAnimation, Modal } from '@/components'
+import { useState } from 'react'
+import { FormProvider, useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import clsx from 'clsx'
+import StarScore from './StarScore'
+
+const schema = z.object({
+    content: z.string().max(50, { message: '리뷰는 50자 이하로 해주세요' }),
+})
+
+type FormData = z.infer<typeof schema>
+
+export default function CreateReviewModal() {
+    const [isLoading, setIsLoading] = useState(false)
+    const [score, setScore] = useState(5)
+    const methods = useForm<FormData>({
+        resolver: zodResolver(schema),
+        mode: 'onChange',
+    })
+
+    const handleFormSubmit = async (data: FormData) => {
+        // 추후 로직 수정
+        setIsLoading(true)
+        setTimeout(() => {
+            console.log('Form Data:', { ...data, score })
+            setIsLoading(false)
+        }, 2000)
+    }
+
+    return (
+        <Modal title="당신의 후기를 남겨주세요!" closeOnOverlayClick={true}>
+            <FormProvider {...methods}>
+                <form
+                    onSubmit={methods.handleSubmit(handleFormSubmit)}
+                    className="flex flex-col items-center gap-4"
+                >
+                    <StarScore score={score} setScore={setScore} />
+                    <CustomInput
+                        id="content"
+                        name="content"
+                        area={true}
+                        placeholder="후기를 작성해보세요!"
+                        disabled={isLoading}
+                    />
+                    <div className="flex w-full justify-end">
+                        <button
+                            type="submit"
+                            disabled={isLoading}
+                            className={clsx(
+                                'btn-solid btn-mobile-lg md:btn-pc-lg',
+                                isLoading && 'btn-loading',
+                            )}
+                        >
+                            {isLoading && <LoopAnimation />}
+                            {isLoading ? 'Loading...' : '제출'}
+                        </button>
+                    </div>
+                </form>
+            </FormProvider>
+        </Modal>
+    )
+}

--- a/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/@modal/[modalType]/_components/IncludeGroupModal.tsx
+++ b/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/@modal/[modalType]/_components/IncludeGroupModal.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { Modal } from '@/components'
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
+
+const groupList = [
+    {
+        _id: '65e8a5d6fc13ae5e7f000001',
+        name: '서울 강남 cs 공부 스터디',
+        description: '서울에 사는 컴공 취준생들의 cs 공부 스터디 그룹입니다.',
+        admin: {},
+        chatRoom: '65e8a5d6fc13ae5e7f000002',
+        memberCount: '7',
+    },
+    {
+        _id: '65e8a5d6fc13ae5e7f000002',
+        name: '서울 강남 cs 공부 스터디',
+        description: '서울에 사는 컴공 취준생들의 cs 공부 스터디 그룹입니다.',
+        admin: {},
+        chatRoom: '65e8a5d6fc13ae5e7f000002',
+        memberCount: '7',
+    },
+    {
+        _id: '65e8a5d6fc13ae5e7f000003',
+        name: '서울 강남 cs 공부 스터디',
+        description: '서울에 사는 컴공 취준생들의 cs 공부 스터디 그룹입니다.',
+        admin: {},
+        chatRoom: '65e8a5d6fc13ae5e7f000002',
+        memberCount: '7',
+    },
+    {
+        _id: '65e8a5d6fc13ae5e7f000004',
+        name: '서울 강남 cs 공부 스터디',
+        description: '서울에 사는 컴공 취준생들의 cs 공부 스터디 그룹입니다.',
+        admin: {},
+        chatRoom: '65e8a5d6fc13ae5e7f000002',
+        memberCount: '7',
+    },
+    {
+        _id: '65e8a5d6fc13ae5e7f000005',
+        name: '서울 강남 cs 공부 스터디',
+        description: '서울에 사는 컴공 취준생들의 cs 공부 스터디 그룹입니다.',
+        admin: {},
+        chatRoom: '65e8a5d6fc13ae5e7f000002',
+        memberCount: '7',
+    },
+]
+
+export default function IncludeGroupModal() {
+    const params = useParams()
+    // 추후 fetch 로직 추가
+
+    return (
+        <Modal title="문제집을 그룹에 추가" closeOnOverlayClick={true}>
+            <div className="flex flex-col items-center gap-4">
+                <div className="custom-scrollbar flex h-[200px] w-full flex-col items-center gap-8 overflow-auto rounded-lg border-2 border-gray-200 bg-point-50 p-4 md:p-8">
+                    {groupList.length === 0 ? (
+                        <span className="text-mobile-body-md font-semi-bold text-gray-500 md:text-pc-body-md">
+                            소속된 그룹이 없습니다!
+                        </span>
+                    ) : (
+                        groupList.map((data) => (
+                            <span
+                                key={data._id}
+                                className="cursor-pointer font-semi-bold md:text-pc-body-md"
+                            >
+                                {data.name}
+                            </span>
+                        ))
+                    )}
+                </div>
+                <Link
+                    href={`/group`}
+                    className="btn-solid btn-mobile-md md:btn-pc-md"
+                >
+                    그룹 검색 페이지로 이동
+                </Link>
+            </div>
+        </Modal>
+    )
+}

--- a/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/@modal/[modalType]/_components/StarScore.tsx
+++ b/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/@modal/[modalType]/_components/StarScore.tsx
@@ -1,0 +1,66 @@
+import StarFullIcon from '@/assets/svgs/star-full.svg'
+import StarEmptyIcon from '@/assets/svgs/star-empty.svg'
+
+interface Props {
+    score: number
+    setScore: React.Dispatch<React.SetStateAction<number>>
+}
+
+export default function StarScore({ score, setScore }: Props) {
+    const onClick = (num: number) => {
+        setScore(num)
+    }
+
+    return (
+        <div className="flex cursor-pointer">
+            <StarFullIcon
+                className="size-9 text-[#FFCC00]"
+                onClick={() => onClick(1)}
+            />
+            {score < 2 ? (
+                <StarEmptyIcon
+                    className="size-9 text-[#FFCC00]"
+                    onClick={() => onClick(2)}
+                />
+            ) : (
+                <StarFullIcon
+                    className="size-9 text-[#FFCC00]"
+                    onClick={() => onClick(2)}
+                />
+            )}
+            {score < 3 ? (
+                <StarEmptyIcon
+                    className="size-9 text-[#FFCC00]"
+                    onClick={() => onClick(3)}
+                />
+            ) : (
+                <StarFullIcon
+                    className="size-9 text-[#FFCC00]"
+                    onClick={() => onClick(3)}
+                />
+            )}
+            {score < 4 ? (
+                <StarEmptyIcon
+                    className="size-9 text-[#FFCC00]"
+                    onClick={() => onClick(4)}
+                />
+            ) : (
+                <StarFullIcon
+                    className="size-9 text-[#FFCC00]"
+                    onClick={() => onClick(4)}
+                />
+            )}
+            {score < 5 ? (
+                <StarEmptyIcon
+                    className="size-9 text-[#FFCC00]"
+                    onClick={() => onClick(5)}
+                />
+            ) : (
+                <StarFullIcon
+                    className="size-9 text-[#FFCC00]"
+                    onClick={() => onClick(5)}
+                />
+            )}
+        </div>
+    )
+}

--- a/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/@modal/[modalType]/page.tsx
+++ b/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/@modal/[modalType]/page.tsx
@@ -1,4 +1,5 @@
 import CreateReviewModal from './_components/CreateReviewModal'
+import IncludeGroupModal from './_components/IncludeGroupModal'
 
 export default async function ModalWrapper({
     params,
@@ -10,8 +11,8 @@ export default async function ModalWrapper({
     switch (modalType) {
         case 'create-review':
             return <CreateReviewModal />
-        // case 'include-group':
-        //     return <IncludeGroupModal />
+        case 'include-group':
+            return <IncludeGroupModal />
         default:
             return null
     }

--- a/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/@modal/[modalType]/page.tsx
+++ b/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/@modal/[modalType]/page.tsx
@@ -1,0 +1,16 @@
+export default async function ModalWrapper({
+    params,
+}: {
+    params: Promise<{ modalType: string }>
+}) {
+    const { modalType } = await params
+
+    switch (modalType) {
+        // case 'create-review':
+        //     return <CreateReviewModal />
+        // case 'include-group':
+        //     return <IncludeGroupModal />
+        default:
+            return null
+    }
+}

--- a/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/@modal/[modalType]/page.tsx
+++ b/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/@modal/[modalType]/page.tsx
@@ -1,3 +1,5 @@
+import CreateReviewModal from './_components/CreateReviewModal'
+
 export default async function ModalWrapper({
     params,
 }: {
@@ -6,8 +8,8 @@ export default async function ModalWrapper({
     const { modalType } = await params
 
     switch (modalType) {
-        // case 'create-review':
-        //     return <CreateReviewModal />
+        case 'create-review':
+            return <CreateReviewModal />
         // case 'include-group':
         //     return <IncludeGroupModal />
         default:

--- a/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/@modal/default.tsx
+++ b/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function ModalDefault() {
+    return null
+}

--- a/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/_components/MobileBottomNav.tsx
+++ b/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/_components/MobileBottomNav.tsx
@@ -2,20 +2,34 @@
 
 import HeartOutlineIcon from '@/assets/svgs/heart-outline.svg'
 import ShareIcon from '@/assets/svgs/share.svg'
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
 
 export default function MobileBottomNav() {
+    const params = useParams()
     // 추후 인증 로직 필요
 
     return (
         <nav className="flex w-full items-center justify-between bg-white px-4 py-3 md:hidden">
             <div className="flex items-center gap-2">
-                <button className="btn-solid btn-mobile-sm py-3">
+                <Link
+                    href={`/quizbook/${params.quizbookId}`}
+                    className="btn-solid btn-mobile-sm py-3"
+                >
                     다시 풀기
-                </button>
-                <button className="btn-solid btn-mobile-sm py-3">해설</button>
-                <button className="btn-solid btn-mobile-sm py-3">
+                </Link>
+                <Link
+                    href={`/quizbook/${params.quizbookId}`}
+                    className="btn-solid btn-mobile-sm py-3"
+                >
+                    해설
+                </Link>
+                <Link
+                    href={`/quizbook/${params.quizbookId}/include-group`}
+                    className="btn-solid btn-mobile-sm py-3"
+                >
                     그룹에 추가
-                </button>
+                </Link>
             </div>
             <div className="flex items-center gap-2">
                 <button className="btn-outline p-2">

--- a/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/_components/Review.tsx
+++ b/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/_components/Review.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import StarFullIcon from '@/assets/svgs/star-full.svg'
 import ReviewList from './ReviewList'
 
-export default function Review() {
+export default function Review({ quizbookId }: { quizbookId: string }) {
     return (
         <section className="flex w-full flex-col gap-4 font-semi-bold">
             <h2 className="text-mobile-body-lg md:text-pc-body-lg">
@@ -22,7 +22,7 @@ export default function Review() {
                     </div>
                 </div>
                 <Link
-                    href={''}
+                    href={`/quizbook/${quizbookId}/create-review`}
                     className="btn-solid btn-mobile-md md:btn-pc-md"
                 >
                     후기 남기기

--- a/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/_components/ReviewCard.tsx
+++ b/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/_components/ReviewCard.tsx
@@ -77,7 +77,7 @@ export default function ReviewCard({
                                 </span>
                             </Link>
                             <Link
-                                href={``}
+                                href={`/quizbook/${params.quizbookId}/delete-review/${_id}`}
                                 className="flex items-center gap-2 md:gap-4"
                             >
                                 <TrashIcon className="size-5" />

--- a/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/_components/ReviewCard.tsx
+++ b/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/_components/ReviewCard.tsx
@@ -10,6 +10,7 @@ import TrashIcon from '@/assets/svgs/trash.svg'
 import Link from 'next/link'
 import { ProfileImage } from '@/components'
 import { useState } from 'react'
+import { useParams } from 'next/navigation'
 
 interface Props {
     _id: string
@@ -29,6 +30,7 @@ export default function ReviewCard({
     myReview,
 }: Props) {
     const [isDropMenuOpen, setIsDropMenuOpen] = useState(false)
+    const params = useParams()
 
     const handleDropMenu = () => {
         setIsDropMenuOpen((prev) => !prev)
@@ -66,7 +68,7 @@ export default function ReviewCard({
                     {isDropMenuOpen && (
                         <div className="absolute right-0 top-5 flex flex-col items-start gap-2 rounded-lg bg-white p-4 shadow-point md:gap-4">
                             <Link
-                                href={``}
+                                href={`/quizbook/${params.quizbookId}/edit-review/${_id}`}
                                 className="flex items-center gap-2 md:gap-4"
                             >
                                 <EditIcon className="size-5" />

--- a/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/_components/SideBar.tsx
+++ b/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/_components/SideBar.tsx
@@ -7,8 +7,10 @@ import UserIcon from '@/assets/svgs/user.svg'
 import StarFullIcon from '@/assets/svgs/star-full.svg'
 import { ProfileImage } from '@/components'
 import Link from 'next/link'
+import { useParams } from 'next/navigation'
 
 export default function SideBar() {
+    const params = useParams()
     // 추후 인증 로직 추가
 
     return (
@@ -17,9 +19,24 @@ export default function SideBar() {
                 {'네트워크 마스터를 위한 OX 퀴즈'}
             </h2>
             <nav className="flex flex-col gap-[10px]">
-                <button className="btn-solid btn-pc-md">다시 풀기</button>
-                <button className="btn-solid btn-pc-md">해설 보기</button>
-                <button className="btn-solid btn-pc-md">그룹에 추가하기</button>
+                <Link
+                    href={`/quizbook/${params.quizbookId}`}
+                    className="btn-solid btn-pc-md text-center"
+                >
+                    다시 풀기
+                </Link>
+                <Link
+                    href={`/quizbook/${params.quizbookId}`}
+                    className="btn-solid btn-pc-md text-center"
+                >
+                    해설 보기
+                </Link>
+                <Link
+                    href={`/quizbook/${params.quizbookId}/include-group`}
+                    className="btn-solid btn-pc-md text-center"
+                >
+                    그룹에 추가하기
+                </Link>
                 <div className="flex w-full gap-[10px]">
                     <button className="h-auth btn-outline btn-pc-md flex flex-1 items-center justify-center gap-2">
                         <HeartOutlineIcon className="size-5" />

--- a/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/layout.tsx
+++ b/src/app/quizbook/(no-layout)/[quizbookId]/(layout)/layout.tsx
@@ -2,22 +2,31 @@ import DesktopHeader from '@/components/DesktopHeader'
 import MobileHeader from '@/components/MobileHeader'
 import MobileBottomNav from './_components/MobileBottomNav'
 
-export default function Layout({ children }: { children: React.ReactNode }) {
+export default function Layout({
+    main,
+    modal,
+}: {
+    main: React.ReactNode
+    modal: React.ReactNode
+}) {
     return (
-        <div className="flex h-screen flex-col items-center font-semi-bold text-gray-900">
-            {/* 데스크탑 전용 헤더 */}
-            <DesktopHeader />
+        <>
+            <div className="flex h-screen flex-col items-center font-semi-bold text-gray-900">
+                {/* 데스크탑 전용 헤더 */}
+                <DesktopHeader />
 
-            {/* 모바일 전용 헤더 */}
-            <MobileHeader title="그룹 정보" backBtn>
-                <MobileHeader.UserMenu />
-            </MobileHeader>
+                {/* 모바일 전용 헤더 */}
+                <MobileHeader title="그룹 정보" backBtn>
+                    <MobileHeader.UserMenu />
+                </MobileHeader>
 
-            {/* 컨탠츠 */}
-            {children}
+                {main}
 
-            {/* 문제 상세 페이지 전용 바텀 Nav */}
-            <MobileBottomNav />
-        </div>
+                {/* 문제 상세 페이지 전용 바텀 Nav */}
+                <MobileBottomNav />
+            </div>
+
+            {modal}
+        </>
     )
 }

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -46,7 +46,7 @@ export default function Modal({
 
     return (
         <div
-            className="absolute inset-0 flex min-h-screen w-full flex-col items-center justify-center bg-gray-900 bg-opacity-70 px-[16px] backdrop-blur-sm md:px-[32px]"
+            className="absolute inset-0 z-20 flex min-h-screen w-full flex-col items-center justify-center bg-gray-900 bg-opacity-70 px-[16px] backdrop-blur-sm md:px-[32px]"
             onClick={handleOverlayClick}
         >
             {/* 모달 컨텐츠 영역 */}


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
- 문제집 상세 페이지에 필요한 모달들을 병렬 라우트로 퍼블리싱 완료했습니다.

## 📌 이슈 넘버
- #34 

## 📝 작업 내용
- 병렬 라우트 폴더 구조 추가
- 후기 생성 모달 퍼블리싱
- 후기 수정 모달 퍼블리싱
- 후기 삭제 모달 퍼블리싱
- 문제집 그룹 선정 모달 퍼블리싱

## 📸 스크린샷(선택)

### 후기 생성 모달
![1](https://github.com/user-attachments/assets/bd403131-8ed0-4d6d-8e2b-962663cc63e5)
![2](https://github.com/user-attachments/assets/814d7879-42cf-4d1a-8762-a52780f38638)

### 후기 수정 모달
![3](https://github.com/user-attachments/assets/142211c8-3e49-4dd7-98e4-8b3c54407283)
![4](https://github.com/user-attachments/assets/16ef8e66-cfce-4dc6-aade-1407db1a69e9)

### 후기 삭제 모달
![5](https://github.com/user-attachments/assets/74117c07-ecfe-431c-80c1-4496b95545d7)
![6](https://github.com/user-attachments/assets/f60d10b8-f842-4492-84c3-40f377405162)

### 문제집 그룹 선정 모달
![7](https://github.com/user-attachments/assets/27f59dc0-0354-40ac-87d4-02f2812401c2)
![8](https://github.com/user-attachments/assets/6d0b2c7d-8d70-40a0-92be-0cdeac1f486d)

close #34 
