### PR TITLE
[FEAT] 그룹 생성 페이지 API 연동

### DIFF
--- a/src/app/group/new/_components/GroupCreateForm.tsx
+++ b/src/app/group/new/_components/GroupCreateForm.tsx
@@ -6,6 +6,9 @@ import { FormProvider, useForm } from 'react-hook-form'
 import * as z from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
 import clsx from 'clsx'
+import { createGroup } from '@/lib/api/group'
+import { useRouter } from 'next/navigation'
+import { toast } from 'sonner'
 
 const schema = z.object({
     name: z
@@ -18,22 +21,26 @@ const schema = z.object({
         .max(50, { message: '그룹 소개는 50자 이하로 해주세요' }),
 })
 
-type FormData = z.infer<typeof schema>
+export type CreateGroupFormData = z.infer<typeof schema>
 
 export default function GroupCreateForm() {
     const [isLoading, setIsLoading] = useState(false)
-    const methods = useForm<FormData>({
+    const methods = useForm<CreateGroupFormData>({
         resolver: zodResolver(schema),
         mode: 'onChange',
     })
+    const router = useRouter()
 
-    const handleFormSubmit = async (data: FormData) => {
-        // 추후 로직 수정
+    const handleFormSubmit = async (data: CreateGroupFormData) => {
         setIsLoading(true)
-        setTimeout(() => {
-            console.log('Form Data:', data)
-            setIsLoading(false)
-        }, 2000)
+        await createGroup(data)
+            .then((res) => {
+                router.push(`/group/${res.data.result._id}/info`)
+            })
+            .catch((error) => {
+                setIsLoading(false)
+                toast(error.response.data.message)
+            })
     }
 
     return (

--- a/src/app/group/new/_components/GroupCreateForm.tsx
+++ b/src/app/group/new/_components/GroupCreateForm.tsx
@@ -56,6 +56,7 @@ export default function GroupCreateForm() {
                         name="description"
                         label="그룹 소개(50자 이하)"
                         placeholder="그룹 소개를 입력해주세요"
+                        area={true}
                         style="solid"
                         disabled={isLoading}
                     />

--- a/src/hooks/queries/user/useCurrentUser.ts
+++ b/src/hooks/queries/user/useCurrentUser.ts
@@ -11,8 +11,8 @@ export const useCurrentUser = () => {
     return useQuery<QueryType>({
         queryKey: QueryKey.user.DEFAULT,
         queryFn: () => getCurrentUser(),
-        staleTime: 1000 * 60 * 10,
-        gcTime: 1000 * 60 * 60,
+        staleTime: 1000 * 60 * 60, // 1시간
+        gcTime: 1000 * 60 * 60 * 10, // 10시간
         retry: 0,
         meta: {
             ignoreGlobalError: true,

--- a/src/lib/api/base.ts
+++ b/src/lib/api/base.ts
@@ -1,0 +1,8 @@
+import axios from 'axios'
+
+const axiosInstance = axios.create({
+    baseURL: process.env.NEXT_PUBLIC_API_URL,
+    withCredentials: true,
+})
+
+export default axiosInstance

--- a/src/lib/api/group/createGroup.ts
+++ b/src/lib/api/group/createGroup.ts
@@ -1,12 +1,10 @@
 import { CreateGroupFormData } from '@/app/group/new/_components/GroupCreateForm'
-import axios from 'axios'
+import axiosInstance from '../base'
 
 /**
  * 그룹을 생성하는 함수
  * @param data 그룹 생성에 필요한 그룹 이름, 그룹 소개 정보
  */
-export const createGroup = async (data: CreateGroupFormData) => {
-    return axios.post(`${process.env.NEXT_PUBLIC_API_URL}/v1/group`, data, {
-        withCredentials: true,
-    })
+export const createGroup = (data: CreateGroupFormData) => {
+    return axiosInstance.post('/v1/group', data)
 }

--- a/src/lib/api/group/createGroup.ts
+++ b/src/lib/api/group/createGroup.ts
@@ -1,0 +1,12 @@
+import { CreateGroupFormData } from '@/app/group/new/_components/GroupCreateForm'
+import axios from 'axios'
+
+/**
+ * 그룹을 생성하는 함수
+ * @param data 그룹 생성에 필요한 그룹 이름, 그룹 소개 정보
+ */
+export const createGroup = async (data: CreateGroupFormData) => {
+    return axios.post(`${process.env.NEXT_PUBLIC_API_URL}/v1/group`, data, {
+        withCredentials: true,
+    })
+}

--- a/src/lib/api/group/index.ts
+++ b/src/lib/api/group/index.ts
@@ -1,0 +1,1 @@
+export * from './createGroup'


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
- 그룹 생성 페이지에 API를 연동하여 페이지의 내부 로직을 완성했습니다.

## 📌 이슈 넘버
- #41 

## 📝 작업 내용

- 그룹 생성 페이지 UI 개선
- 그룹 생성 요청 함수 작성
- 그룹 생성 페이지 form 제출 핸들러 완성
- 공통 axiosInstance 작성
> [!NOTE]
> DRY 원칙(Don't Repeat Yourself)을 지키며, 공통 설정을 한 곳에서 관리할 수 있습니다. 그래서 코드가 간소화되고 유지보수가 쉬워지도록 공통 axiosInstance를 만들게 되었습니다.

## 📸 스크린샷(선택)
### Desktop
![1](https://github.com/user-attachments/assets/01fbaaa2-7a97-407f-a7b3-4778a593917e)
### Mobile
![2](https://github.com/user-attachments/assets/35e4e220-56c9-4ce9-aaa8-ff372ab681aa)

## 💬리뷰 요구사항(선택)

close #41 
