### PR TITLE
[FEAT] 그룹 정보 페이지 API 연동

### DIFF
--- a/src/app/group/[groupId]/info/@main/_components/DeleteBtn.tsx
+++ b/src/app/group/[groupId]/info/@main/_components/DeleteBtn.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { useCurrentUser, useGroupQuery } from '@/hooks/queries'
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
+
+export default function DeleteBtn() {
+    const { groupId } = useParams()
+    const { data: groupData } = useGroupQuery(groupId as string)
+    const { data: userData } = useCurrentUser()
+
+    return groupData?.admin._id === userData?._id ? (
+        <Link
+            href={`/group/${groupId}/info/delete`}
+            className="text-mobile-body-sm font-regular text-gray-500 underline md:text-pc-body-sm"
+        >
+            그룹 삭제
+        </Link>
+    ) : (
+        <div></div>
+    )
+}

--- a/src/app/group/[groupId]/info/@main/_components/GroupInfo.tsx
+++ b/src/app/group/[groupId]/info/@main/_components/GroupInfo.tsx
@@ -18,7 +18,7 @@ const schema = z.object({
         .max(50, { message: '그룹 소개는 50자 이하로 해주세요' }),
 })
 
-type FormData = z.infer<typeof schema>
+export type GroupInfoFormData = z.infer<typeof schema>
 
 export default function GroupInfo() {
     const [isLoading, setIsLoading] = useState(false)
@@ -27,7 +27,7 @@ export default function GroupInfo() {
         name: '',
         description: '',
     })
-    const methods = useForm<FormData>({
+    const methods = useForm<GroupInfoFormData>({
         resolver: zodResolver(schema),
         mode: 'onChange',
         defaultValues: backUp,
@@ -46,7 +46,7 @@ export default function GroupInfo() {
         })
     }, [reset, setBackUp])
 
-    const handleFormSubmit = async (data: FormData) => {
+    const handleFormSubmit = async (data: GroupInfoFormData) => {
         // 추후 로직 수정
         setIsLoading(true)
         setTimeout(() => {

--- a/src/app/group/[groupId]/info/@main/_components/GroupInfo.tsx
+++ b/src/app/group/[groupId]/info/@main/_components/GroupInfo.tsx
@@ -7,10 +7,11 @@ import { extractKSTDateOnly } from '@/utils/date/dateOnly'
 import { zodResolver } from '@hookform/resolvers/zod'
 import clsx from 'clsx'
 import Link from 'next/link'
-import { useParams } from 'next/navigation'
+import { useParams, useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import * as z from 'zod'
+import InfoItem from './InfoItem'
 
 const schema = z.object({
     name: z
@@ -37,11 +38,12 @@ export default function GroupInfo() {
         defaultValues: backUp,
     })
     const { groupId } = useParams()
-    const { data, isLoading } = useGroupQuery(groupId as string)
+    const { data, error } = useGroupQuery(groupId as string)
     const { mutate, isPending } = usePatchGroup(groupId as string, () => {
         setIsChangeMode(false)
     })
     const { data: userData } = useCurrentUser()
+    const router = useRouter()
 
     const { reset } = methods
 
@@ -50,6 +52,12 @@ export default function GroupInfo() {
         reset({ name: data.name, description: data.description })
         setBackUp({ name: data.name, description: data.description })
     }, [reset, setBackUp, data])
+
+    useEffect(() => {
+        if (error) {
+            router.push('/group')
+        }
+    }, [error, router])
 
     const handleFormSubmit = (data: GroupInfoFormData) => {
         mutate(data)
@@ -67,31 +75,43 @@ export default function GroupInfo() {
                     className="flex w-full flex-col items-center gap-3"
                 >
                     <div className="flex w-full flex-col gap-4">
-                        <CustomInput
-                            id="name"
-                            name="name"
-                            label="그룹 이름"
-                            placeholder={
-                                data
-                                    ? '그룹 이름을 입력해주세요'
-                                    : '잠시만 기다려주세요...'
-                            }
-                            style="solid"
-                            disabled={isLoading || isPending || !isChangeMode}
-                        />
-                        <CustomInput
-                            id="description"
-                            name="description"
-                            label="그룹 소개(50자 이하)"
-                            placeholder={
-                                data
-                                    ? '그룹 소개를 입력해주세요'
-                                    : '잠시만 기다려주세요...'
-                            }
-                            style="solid"
-                            area={true}
-                            disabled={isLoading || isPending || !isChangeMode}
-                        />
+                        {isChangeMode ? (
+                            <>
+                                <CustomInput
+                                    id="name"
+                                    name="name"
+                                    label="그룹 이름"
+                                    placeholder="그룹 이름을 입력해주세요"
+                                    style="solid"
+                                    disabled={isPending}
+                                />
+                                <CustomInput
+                                    id="description"
+                                    name="description"
+                                    label="그룹 소개(50자 이하)"
+                                    placeholder="그룹 소개를 입력해주세요"
+                                    style="solid"
+                                    area={true}
+                                    disabled={isPending}
+                                />
+                            </>
+                        ) : (
+                            <>
+                                <InfoItem
+                                    label="그룹 이름"
+                                    text={
+                                        data?.name || '잠시만 기다려주세요...'
+                                    }
+                                />
+                                <InfoItem
+                                    label="그룹 소개(50자 이하)"
+                                    text={
+                                        data?.description ||
+                                        '잠시만 기다려주세요...'
+                                    }
+                                />
+                            </>
+                        )}
                         <div className="flex w-full gap-4 pb-4">
                             <div className="flex flex-1 flex-col items-start gap-1">
                                 <span className="text-mobile-body-sm font-regular text-gray-500 md:text-pc-body-sm">
@@ -129,7 +149,7 @@ export default function GroupInfo() {
                         (isChangeMode ? (
                             <div className="flex w-full gap-[10px]">
                                 <button
-                                    disabled={isLoading || isPending}
+                                    disabled={isPending}
                                     className="btn-outline btn-mobile-lg flex-1 md:btn-pc-lg"
                                     onClick={handleCancel}
                                 >
@@ -137,18 +157,14 @@ export default function GroupInfo() {
                                 </button>
                                 <button
                                     type="submit"
-                                    disabled={isLoading || isPending}
+                                    disabled={isPending}
                                     className={clsx(
                                         'btn-solid btn-mobile-lg flex-1 md:btn-pc-lg',
-                                        isLoading && 'btn-loading',
+                                        isPending && 'btn-loading',
                                     )}
                                 >
-                                    {(isLoading || isPending) && (
-                                        <LoopAnimation />
-                                    )}
-                                    {isLoading || isPending
-                                        ? 'Loading...'
-                                        : '저장'}
+                                    {isPending && <LoopAnimation />}
+                                    {isPending ? 'Loading...' : '저장'}
                                 </button>
                             </div>
                         ) : (

--- a/src/app/group/[groupId]/info/@main/_components/GroupInfo.tsx
+++ b/src/app/group/[groupId]/info/@main/_components/GroupInfo.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { CustomInput, LoopAnimation, ProfileImage } from '@/components'
-import { useGroupQuery } from '@/hooks/queries'
+import { usePatchGroup } from '@/hooks/mutations'
+import { useCurrentUser, useGroupQuery } from '@/hooks/queries'
 import { extractKSTDateOnly } from '@/utils/date/dateOnly'
 import { zodResolver } from '@hookform/resolvers/zod'
 import clsx from 'clsx'
@@ -25,7 +26,6 @@ const schema = z.object({
 export type GroupInfoFormData = z.infer<typeof schema>
 
 export default function GroupInfo() {
-    const [isLoading, setIsLoading] = useState(false)
     const [isChangeMode, setIsChangeMode] = useState(false)
     const [backUp, setBackUp] = useState({
         name: '',
@@ -37,7 +37,9 @@ export default function GroupInfo() {
         defaultValues: backUp,
     })
     const { groupId } = useParams()
-    const { data } = useGroupQuery(groupId as string)
+    const { data, isLoading } = useGroupQuery(groupId as string)
+    const { mutate, isPending } = usePatchGroup(groupId as string)
+    const { data: userData } = useCurrentUser()
 
     const { reset } = methods
 
@@ -47,15 +49,9 @@ export default function GroupInfo() {
         setBackUp({ name: data.name, description: data.description })
     }, [reset, setBackUp, data])
 
-    const handleFormSubmit = async (data: GroupInfoFormData) => {
-        // 추후 로직 수정
-        setIsLoading(true)
-        setTimeout(() => {
-            console.log('Form Data:', data)
-            setIsLoading(false)
-            setBackUp(data)
-            setIsChangeMode(false)
-        }, 2000)
+    const handleFormSubmit = (data: GroupInfoFormData) => {
+        mutate(data)
+        setIsChangeMode(false)
     }
     const handleCancel = () => {
         reset(backUp)
@@ -80,7 +76,7 @@ export default function GroupInfo() {
                                     : '잠시만 기다려주세요...'
                             }
                             style="solid"
-                            disabled={isLoading || !isChangeMode}
+                            disabled={isLoading || isPending || !isChangeMode}
                         />
                         <CustomInput
                             id="description"
@@ -92,7 +88,7 @@ export default function GroupInfo() {
                                     : '잠시만 기다려주세요...'
                             }
                             style="solid"
-                            disabled={isLoading || !isChangeMode}
+                            disabled={isLoading || isPending || !isChangeMode}
                         />
                         <div className="flex w-full gap-4 pb-4">
                             <div className="flex flex-1 flex-col items-start gap-1">
@@ -127,36 +123,41 @@ export default function GroupInfo() {
                             </div>
                         </div>
                     </div>
-                    {isChangeMode ? (
-                        <div className="flex w-full gap-[10px]">
+                    {data?.admin._id === userData?._id &&
+                        (isChangeMode ? (
+                            <div className="flex w-full gap-[10px]">
+                                <button
+                                    disabled={isLoading || isPending}
+                                    className="btn-outline btn-mobile-lg flex-1 md:btn-pc-lg"
+                                    onClick={handleCancel}
+                                >
+                                    취소
+                                </button>
+                                <button
+                                    type="submit"
+                                    disabled={isLoading || isPending}
+                                    className={clsx(
+                                        'btn-solid btn-mobile-lg flex-1 md:btn-pc-lg',
+                                        isLoading && 'btn-loading',
+                                    )}
+                                >
+                                    {(isLoading || isPending) && (
+                                        <LoopAnimation />
+                                    )}
+                                    {isLoading || isPending
+                                        ? 'Loading...'
+                                        : '저장'}
+                                </button>
+                            </div>
+                        ) : (
                             <button
-                                disabled={isLoading}
-                                className="btn-outline btn-mobile-lg flex-1 md:btn-pc-lg"
-                                onClick={handleCancel}
+                                className="btn-solid btn-mobile-lg w-full flex-1 md:btn-pc-lg"
+                                onClick={() => setIsChangeMode(true)}
+                                disabled={!data}
                             >
-                                취소
+                                수정하기
                             </button>
-                            <button
-                                type="submit"
-                                disabled={isLoading}
-                                className={clsx(
-                                    'btn-solid btn-mobile-lg flex-1 md:btn-pc-lg',
-                                    isLoading && 'btn-loading',
-                                )}
-                            >
-                                {isLoading && <LoopAnimation />}
-                                {isLoading ? 'Loading...' : '저장'}
-                            </button>
-                        </div>
-                    ) : (
-                        <button
-                            className="btn-solid btn-mobile-lg w-full flex-1 md:btn-pc-lg"
-                            onClick={() => setIsChangeMode(true)}
-                            disabled={!data}
-                        >
-                            수정하기
-                        </button>
-                    )}
+                        ))}
                 </form>
             </FormProvider>
         </section>

--- a/src/app/group/[groupId]/info/@main/_components/GroupInfo.tsx
+++ b/src/app/group/[groupId]/info/@main/_components/GroupInfo.tsx
@@ -38,7 +38,9 @@ export default function GroupInfo() {
     })
     const { groupId } = useParams()
     const { data, isLoading } = useGroupQuery(groupId as string)
-    const { mutate, isPending } = usePatchGroup(groupId as string)
+    const { mutate, isPending } = usePatchGroup(groupId as string, () => {
+        setIsChangeMode(false)
+    })
     const { data: userData } = useCurrentUser()
 
     const { reset } = methods
@@ -51,7 +53,6 @@ export default function GroupInfo() {
 
     const handleFormSubmit = (data: GroupInfoFormData) => {
         mutate(data)
-        setIsChangeMode(false)
     }
     const handleCancel = () => {
         reset(backUp)
@@ -88,6 +89,7 @@ export default function GroupInfo() {
                                     : '잠시만 기다려주세요...'
                             }
                             style="solid"
+                            area={true}
                             disabled={isLoading || isPending || !isChangeMode}
                         />
                         <div className="flex w-full gap-4 pb-4">

--- a/src/app/group/[groupId]/info/@main/_components/GroupInfo.tsx
+++ b/src/app/group/[groupId]/info/@main/_components/GroupInfo.tsx
@@ -1,8 +1,12 @@
 'use client'
 
 import { CustomInput, LoopAnimation, ProfileImage } from '@/components'
+import { useGroupQuery } from '@/hooks/queries'
+import { extractKSTDateOnly } from '@/utils/date/dateOnly'
 import { zodResolver } from '@hookform/resolvers/zod'
 import clsx from 'clsx'
+import Link from 'next/link'
+import { useParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import * as z from 'zod'
@@ -32,19 +36,16 @@ export default function GroupInfo() {
         mode: 'onChange',
         defaultValues: backUp,
     })
+    const { groupId } = useParams()
+    const { data } = useGroupQuery(groupId as string)
 
     const { reset } = methods
 
     useEffect(() => {
-        reset({
-            name: '봄바르딜로 크로커딜로',
-            description: '퉁퉁퉁퉁퉁퉁 사후르',
-        })
-        setBackUp({
-            name: '봄바르딜로 크로커딜로',
-            description: '퉁퉁퉁퉁퉁퉁 사후르',
-        })
-    }, [reset, setBackUp])
+        if (!data) return
+        reset({ name: data.name, description: data.description })
+        setBackUp({ name: data.name, description: data.description })
+    }, [reset, setBackUp, data])
 
     const handleFormSubmit = async (data: GroupInfoFormData) => {
         // 추후 로직 수정
@@ -73,7 +74,11 @@ export default function GroupInfo() {
                             id="name"
                             name="name"
                             label="그룹 이름"
-                            placeholder="그룹 이름을 입력해주세요"
+                            placeholder={
+                                data
+                                    ? '그룹 이름을 입력해주세요'
+                                    : '잠시만 기다려주세요...'
+                            }
                             style="solid"
                             disabled={isLoading || !isChangeMode}
                         />
@@ -81,7 +86,11 @@ export default function GroupInfo() {
                             id="description"
                             name="description"
                             label="그룹 소개(50자 이하)"
-                            placeholder="그룹 소개를 입력해주세요"
+                            placeholder={
+                                data
+                                    ? '그룹 소개를 입력해주세요'
+                                    : '잠시만 기다려주세요...'
+                            }
                             style="solid"
                             disabled={isLoading || !isChangeMode}
                         />
@@ -90,19 +99,30 @@ export default function GroupInfo() {
                                 <span className="text-mobile-body-sm font-regular text-gray-500 md:text-pc-body-sm">
                                     그룹장
                                 </span>
-                                <div className="flex cursor-pointer items-center gap-2">
-                                    <ProfileImage size={32} profileImg={''} />
+                                <Link
+                                    href={`/user/${data?.admin._id}`}
+                                    className="flex cursor-pointer items-center gap-2"
+                                >
+                                    {data && (
+                                        <ProfileImage
+                                            size={32}
+                                            profileImg={`${data?.admin.profileImg}`}
+                                        />
+                                    )}
                                     <span className="text-mobile-body-md font-semi-bold md:text-pc-body-md">
-                                        닉네임
+                                        {data?.admin.nickname ||
+                                            '잠시만 기다려주세요...'}
                                     </span>
-                                </div>
+                                </Link>
                             </div>
                             <div className="flex flex-1 flex-col items-start gap-1">
                                 <span className="text-mobile-body-sm font-regular text-gray-500 md:text-pc-body-sm">
                                     그룹 생성일
                                 </span>
                                 <span className="text-mobile-body-md font-semi-bold md:text-pc-body-md">
-                                    2025-03-21
+                                    {data
+                                        ? extractKSTDateOnly(data.createdAt)
+                                        : '잠시만 기다려주세요...'}
                                 </span>
                             </div>
                         </div>
@@ -132,6 +152,7 @@ export default function GroupInfo() {
                         <button
                             className="btn-solid btn-mobile-lg w-full flex-1 md:btn-pc-lg"
                             onClick={() => setIsChangeMode(true)}
+                            disabled={!data}
                         >
                             수정하기
                         </button>

--- a/src/app/group/[groupId]/info/@main/_components/InfoItem.tsx
+++ b/src/app/group/[groupId]/info/@main/_components/InfoItem.tsx
@@ -1,0 +1,17 @@
+type Props = {
+    label: string
+    text: string
+}
+
+export default function InfoItem({ label, text }: Props) {
+    return (
+        <div className="flex flex-col items-start gap-1 pb-4">
+            <span className="text-mobile-body-sm font-regular text-gray-500 md:text-pc-body-sm">
+                {label}
+            </span>
+            <span className="whitespace-pre-line text-mobile-body-md font-semi-bold md:text-pc-body-md">
+                {text}
+            </span>
+        </div>
+    )
+}

--- a/src/app/group/[groupId]/info/@main/page.tsx
+++ b/src/app/group/[groupId]/info/@main/page.tsx
@@ -4,7 +4,7 @@ import GroupChatIcon from '@/assets/svgs/group-chat.svg'
 import MemberIcon from '@/assets/svgs/member.svg'
 import Sidebar from '@/components/Sidebar'
 import GroupInfo from './_components/GroupInfo'
-import Link from 'next/link'
+import DeleteBtn from './_components/DeleteBtn'
 
 export default async function GroupInfoPage({
     params,
@@ -47,12 +47,7 @@ export default async function GroupInfoPage({
                         </Sidebar>
                     </div>
                 </div>
-                <Link
-                    href={`/group/${groupId}/info/delete`}
-                    className="text-mobile-body-sm font-regular text-gray-500 underline md:text-pc-body-sm"
-                >
-                    그룹 삭제
-                </Link>
+                <DeleteBtn />
             </main>
         </>
     )

--- a/src/app/group/[groupId]/info/@modal/delete/page.tsx
+++ b/src/app/group/[groupId]/info/@modal/delete/page.tsx
@@ -1,21 +1,16 @@
 'use client'
 
 import { LoopAnimation, Modal } from '@/components'
+import { useDeleteGroup } from '@/hooks/mutations/group/useDeleteGroup'
 import clsx from 'clsx'
 import { useParams } from 'next/navigation'
-import { useState } from 'react'
 
 export default function DeleteGroupModal() {
-    const [isLoading, setIsLoading] = useState(false)
-    const params = useParams()
+    const { groupId } = useParams()
+    const { mutate, isPending } = useDeleteGroup(groupId as string)
 
     const handleClick = () => {
-        // 추후 로직 수정
-        setIsLoading(true)
-        setTimeout(() => {
-            console.log(1)
-            setIsLoading(false)
-        }, 2000)
+        mutate()
     }
 
     return (
@@ -24,18 +19,18 @@ export default function DeleteGroupModal() {
                 <div className="flex w-full flex-col items-center gap-2 rounded-lg border-2 border-gray-200 bg-point-50 p-4 text-mobile-body-md font-semi-bold text-gray-500 md:p-8 md:text-pc-body-md">
                     <span>해당 그룹을 삭제하시겠습니까?</span>
                     <span>한번 삭제하면</span>
-                    <span>복구할 수 없습니다!</span>
+                    <span className="text-danger-300">복구할 수 없습니다!</span>
                 </div>
                 <button
-                    disabled={isLoading}
+                    disabled={isPending}
                     className={clsx(
                         'btn-solid btn-mobile-md bg-danger-300 md:btn-pc-md',
-                        isLoading && 'btn-loading',
+                        isPending && 'btn-loading',
                     )}
                     onClick={handleClick}
                 >
-                    {isLoading && <LoopAnimation />}
-                    {isLoading ? 'Loading...' : '삭제'}
+                    {isPending && <LoopAnimation />}
+                    {isPending ? 'Loading...' : '삭제'}
                 </button>
             </div>
         </Modal>

--- a/src/app/group/new/_components/GroupCreateForm.tsx
+++ b/src/app/group/new/_components/GroupCreateForm.tsx
@@ -6,9 +6,9 @@ import { FormProvider, useForm } from 'react-hook-form'
 import * as z from 'zod'
 import { zodResolver } from '@hookform/resolvers/zod'
 import clsx from 'clsx'
-import { createGroup } from '@/lib/api/group'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
+import { postGroup } from '@/lib/api'
 
 const schema = z.object({
     name: z
@@ -33,7 +33,7 @@ export default function GroupCreateForm() {
 
     const handleFormSubmit = async (data: CreateGroupFormData) => {
         setIsLoading(true)
-        await createGroup(data)
+        await postGroup(data)
             .then((res) => {
                 router.push(`/group/${res.data.result._id}/info`)
             })

--- a/src/app/group/new/_components/GroupCreateForm.tsx
+++ b/src/app/group/new/_components/GroupCreateForm.tsx
@@ -35,7 +35,7 @@ export default function GroupCreateForm() {
         setIsLoading(true)
         await postGroup(data)
             .then((res) => {
-                router.push(`/group/${res.data.result._id}/info`)
+                router.push(`/group/${res._id}/info`)
             })
             .catch((error) => {
                 setIsLoading(false)

--- a/src/constants/common/gcTime.ts
+++ b/src/constants/common/gcTime.ts
@@ -1,0 +1,3 @@
+export const GcTime = {
+    DEFAULT: 1000 * 60 * 60 * 10, // 10시간
+}

--- a/src/constants/common/staleTime.ts
+++ b/src/constants/common/staleTime.ts
@@ -1,0 +1,3 @@
+export const StaleTime = {
+    DEFAULT: 1000 * 60 * 60, // 1시간
+}

--- a/src/hooks/mutations/group/index.ts
+++ b/src/hooks/mutations/group/index.ts
@@ -1,0 +1,1 @@
+export * from './usePatchGroup'

--- a/src/hooks/mutations/group/useDeleteGroup.ts
+++ b/src/hooks/mutations/group/useDeleteGroup.ts
@@ -1,0 +1,20 @@
+import { deleteGroup } from '@/lib/api'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { useRouter } from 'next/navigation'
+
+/**
+ * 그룹을 삭제하는 mutation
+ */
+export const useDeleteGroup = (groupId: string) => {
+    const queryClient = useQueryClient()
+    const router = useRouter()
+
+    return useMutation({
+        mutationFn: () => deleteGroup(groupId),
+        retry: 0,
+        onSuccess: () => {
+            queryClient.removeQueries({ queryKey: ['group', groupId] })
+            router.push('/group')
+        },
+    })
+}

--- a/src/hooks/mutations/group/usePatchGroup.ts
+++ b/src/hooks/mutations/group/usePatchGroup.ts
@@ -1,0 +1,27 @@
+import { GroupInfoFormData } from '@/app/group/[groupId]/info/@main/_components/GroupInfo'
+import { patchGroup } from '@/lib/api'
+import { Group } from '@/types/group'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+/**
+ * 그룹 정보를 수정하는 mutation
+ */
+export const usePatchGroup = (groupId: string) => {
+    const queryClient = useQueryClient()
+
+    return useMutation({
+        mutationFn: (data: GroupInfoFormData) => patchGroup(groupId, data),
+        retry: 0,
+        onSuccess: (_, variables) => {
+            queryClient.setQueryData(['group', groupId], (oldData: Group) => {
+                return {
+                    ...oldData,
+                    name: variables.name,
+                    description: variables.description,
+                }
+            })
+            toast('그룹 정보 수정이 완료되었습니다!')
+        },
+    })
+}

--- a/src/hooks/mutations/group/usePatchGroup.ts
+++ b/src/hooks/mutations/group/usePatchGroup.ts
@@ -7,7 +7,10 @@ import { toast } from 'sonner'
 /**
  * 그룹 정보를 수정하는 mutation
  */
-export const usePatchGroup = (groupId: string) => {
+export const usePatchGroup = (
+    groupId: string,
+    onSuccessCallback?: () => void,
+) => {
     const queryClient = useQueryClient()
 
     return useMutation({
@@ -21,6 +24,7 @@ export const usePatchGroup = (groupId: string) => {
                     description: variables.description,
                 }
             })
+            onSuccessCallback?.()
             toast('그룹 정보 수정이 완료되었습니다!')
         },
     })

--- a/src/hooks/mutations/index.ts
+++ b/src/hooks/mutations/index.ts
@@ -1,0 +1,1 @@
+export * from './group'

--- a/src/hooks/queries/group/index.ts
+++ b/src/hooks/queries/group/index.ts
@@ -1,0 +1,1 @@
+export * from './useGroupQuery'

--- a/src/hooks/queries/group/useGroupQuery.ts
+++ b/src/hooks/queries/group/useGroupQuery.ts
@@ -1,0 +1,17 @@
+import { GcTime } from '@/constants/common/gcTime'
+import { StaleTime } from '@/constants/common/staleTime'
+import { getGroup } from '@/lib/api'
+import { useQuery } from '@tanstack/react-query'
+
+/**
+ * 그룹 정보를 가져오는 query
+ */
+export const useGroupQuery = (groupId: string) => {
+    return useQuery({
+        queryKey: ['group', groupId],
+        queryFn: () => getGroup(groupId),
+        staleTime: StaleTime.DEFAULT,
+        gcTime: GcTime.DEFAULT,
+        retry: 0,
+    })
+}

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -1,1 +1,2 @@
 export * from './user'
+export * from './group'

--- a/src/hooks/queries/user/useCurrentUser.ts
+++ b/src/hooks/queries/user/useCurrentUser.ts
@@ -1,6 +1,8 @@
 import { useQuery } from '@tanstack/react-query'
 import { QueryKey } from '@/constants/common/queryKey'
 import { getCurrentUser } from '@/lib/api/user'
+import { StaleTime } from '@/constants/common/staleTime'
+import { GcTime } from '@/constants/common/gcTime'
 
 type QueryType = Awaited<ReturnType<typeof getCurrentUser>>
 
@@ -11,8 +13,8 @@ export const useCurrentUser = () => {
     return useQuery<QueryType>({
         queryKey: QueryKey.user.DEFAULT,
         queryFn: () => getCurrentUser(),
-        staleTime: 1000 * 60 * 60, // 1시간
-        gcTime: 1000 * 60 * 60 * 10, // 10시간
+        staleTime: StaleTime.DEFAULT,
+        gcTime: GcTime.DEFAULT,
         retry: 0,
         meta: {
             ignoreGlobalError: true,

--- a/src/lib/api/group/deleteGroup.ts
+++ b/src/lib/api/group/deleteGroup.ts
@@ -4,6 +4,6 @@ import axiosInstance from '../base'
  * 그룹을 삭제하는 함수
  * @param groupId 삭제하고자 하는 그룹의 ID
  */
-export const deleteGroup = (groupId: string) => {
-    return axiosInstance.delete(`/v1/group/${groupId}`)
+export const deleteGroup = async (groupId: string) => {
+    await axiosInstance.delete(`/v1/group/${groupId}`)
 }

--- a/src/lib/api/group/deleteGroup.ts
+++ b/src/lib/api/group/deleteGroup.ts
@@ -1,0 +1,9 @@
+import axiosInstance from '../base'
+
+/**
+ * 그룹을 삭제하는 함수
+ * @param groupId 삭제하고자 하는 그룹의 ID
+ */
+export const deleteGroup = (groupId: string) => {
+    return axiosInstance.delete(`/v1/group/${groupId}`)
+}

--- a/src/lib/api/group/getGroup.ts
+++ b/src/lib/api/group/getGroup.ts
@@ -1,0 +1,9 @@
+import axiosInstance from '../base'
+
+/**
+ * 그룹 정보를 조회하는 함수
+ * @param groupId 정보를 조회하고자 하는 그룹의 ID
+ */
+export const getGroup = (groupId: string) => {
+    return axiosInstance.get(`/v1/group/${groupId}`)
+}

--- a/src/lib/api/group/getGroup.ts
+++ b/src/lib/api/group/getGroup.ts
@@ -1,9 +1,13 @@
+import { Group } from '@/types/group'
 import axiosInstance from '../base'
 
 /**
  * 그룹 정보를 조회하는 함수
  * @param groupId 정보를 조회하고자 하는 그룹의 ID
  */
-export const getGroup = (groupId: string) => {
-    return axiosInstance.get(`/v1/group/${groupId}`)
+export const getGroup = async (groupId: string) => {
+    const res = await axiosInstance.get<{ result: Group }>(
+        `/v1/group/${groupId}`,
+    )
+    return res.data.result
 }

--- a/src/lib/api/group/index.ts
+++ b/src/lib/api/group/index.ts
@@ -1,1 +1,4 @@
-export * from './createGroup'
+export * from './postGroup'
+export * from './getGroup'
+export * from './patchGroup'
+export * from './deleteGroup'

--- a/src/lib/api/group/patchGroup.ts
+++ b/src/lib/api/group/patchGroup.ts
@@ -1,0 +1,11 @@
+import { GroupInfoFormData } from '@/app/group/[groupId]/info/@main/_components/GroupInfo'
+import axiosInstance from '../base'
+
+/**
+ * 그룹 정보를 수정하는 함수
+ * @param groupId 수정하고자 하는 그룹의 ID
+ * @param data 그룹 정보 수정 내용
+ */
+export const patchGroup = (groupId: string, data: GroupInfoFormData) => {
+    return axiosInstance.patch(`/v1/group/${groupId}`, data)
+}

--- a/src/lib/api/group/patchGroup.ts
+++ b/src/lib/api/group/patchGroup.ts
@@ -6,6 +6,6 @@ import axiosInstance from '../base'
  * @param groupId 수정하고자 하는 그룹의 ID
  * @param data 그룹 정보 수정 내용
  */
-export const patchGroup = (groupId: string, data: GroupInfoFormData) => {
-    return axiosInstance.patch(`/v1/group/${groupId}`, data)
+export const patchGroup = async (groupId: string, data: GroupInfoFormData) => {
+    await axiosInstance.patch(`/v1/group/${groupId}`, data)
 }

--- a/src/lib/api/group/postGroup.ts
+++ b/src/lib/api/group/postGroup.ts
@@ -5,6 +5,6 @@ import axiosInstance from '../base'
  * 그룹을 생성하는 함수
  * @param data 그룹 생성에 필요한 그룹 이름, 그룹 소개 정보
  */
-export const createGroup = (data: CreateGroupFormData) => {
+export const postGroup = (data: CreateGroupFormData) => {
     return axiosInstance.post('/v1/group', data)
 }

--- a/src/lib/api/group/postGroup.ts
+++ b/src/lib/api/group/postGroup.ts
@@ -5,6 +5,10 @@ import axiosInstance from '../base'
  * 그룹을 생성하는 함수
  * @param data 그룹 생성에 필요한 그룹 이름, 그룹 소개 정보
  */
-export const postGroup = (data: CreateGroupFormData) => {
-    return axiosInstance.post('/v1/group', data)
+export const postGroup = async (data: CreateGroupFormData) => {
+    const res = await axiosInstance.post<{ result: { _id: string } }>(
+        '/v1/group',
+        data,
+    )
+    return res.data.result
 }

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,0 +1,2 @@
+export * from './base'
+export * from './group'

--- a/src/lib/react-query/getQueryClient.ts
+++ b/src/lib/react-query/getQueryClient.ts
@@ -2,6 +2,7 @@ import {
     QueryClient,
     defaultShouldDehydrateQuery,
     QueryCache,
+    MutationCache,
 } from '@tanstack/react-query'
 import axios from 'axios'
 import { toast } from 'sonner'
@@ -23,6 +24,21 @@ const makeQueryClient = () => {
         queryCache: new QueryCache({
             onError: (error, query) => {
                 const meta = query?.meta as Record<string, boolean>
+                if (isClient && !meta?.ignoreGlobalError) {
+                    let message = '알 수 없는 에러가 발생했습니다.'
+                    if (axios.isAxiosError(error)) {
+                        // 서버에서 내려준 메시지 우선
+                        message = error.response?.data?.message || error.message
+                    } else if (error instanceof Error) {
+                        message = error.message
+                    }
+                    toast(message)
+                }
+            },
+        }),
+        mutationCache: new MutationCache({
+            onError: (error, _a, _b, mutation) => {
+                const meta = mutation?.meta as Record<string, boolean>
                 if (isClient && !meta?.ignoreGlobalError) {
                     let message = '알 수 없는 에러가 발생했습니다.'
                     if (axios.isAxiosError(error)) {

--- a/src/lib/react-query/getQueryClient.ts
+++ b/src/lib/react-query/getQueryClient.ts
@@ -3,6 +3,7 @@ import {
     defaultShouldDehydrateQuery,
     QueryCache,
 } from '@tanstack/react-query'
+import axios from 'axios'
 import { toast } from 'sonner'
 
 let browserQueryClient: QueryClient | undefined = undefined
@@ -23,7 +24,14 @@ const makeQueryClient = () => {
             onError: (error, query) => {
                 const meta = query?.meta as Record<string, boolean>
                 if (isClient && !meta?.ignoreGlobalError) {
-                    toast(error.message)
+                    let message = '알 수 없는 에러가 발생했습니다.'
+                    if (axios.isAxiosError(error)) {
+                        // 서버에서 내려준 메시지 우선
+                        message = error.response?.data?.message || error.message
+                    } else if (error instanceof Error) {
+                        message = error.message
+                    }
+                    toast(message)
                 }
             },
         }),

--- a/src/types/group.d.ts
+++ b/src/types/group.d.ts
@@ -1,4 +1,4 @@
-export interface Group {
+export interface GroupCard {
     _id: string
     name: string
     description: string
@@ -9,4 +9,29 @@ export interface Group {
     }
     memberCount: number
     chatRoom?: string
+}
+
+export interface Group {
+    _id: string
+    name: string
+    description: string
+    admin: {
+        _id: string
+        nickname: string
+        profileImg: string
+    }
+    memberList: {
+        _id: string
+        nickname: string
+        profileImg: string
+        email: string
+    }[]
+    applyingUserList: {
+        _id: string
+        nickname: string
+        profileImg: string
+        email: string
+    }[]
+    chatRoom: string
+    createdAt: string
 }

--- a/src/utils/date/dateOnly.ts
+++ b/src/utils/date/dateOnly.ts
@@ -1,0 +1,10 @@
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+import timezone from 'dayjs/plugin/timezone'
+
+dayjs.extend(utc)
+dayjs.extend(timezone)
+
+export function extractKSTDateOnly(isoString: string) {
+    return dayjs(isoString).tz('Asia/Seoul').format('YYYY-MM-DD')
+}


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
- 그룹 정보 페이지에 API를 연동하여 페이지의 내부 로직을 완성했습니다.

## 📌 이슈 넘버
- #43 

## 📝 작업 내용
### ✅ mutation 전역 에러 핸들링 추가
> [!NOTE]
> 코드 간소화를 위해 mutation에 대한 전역 에러 핸들링을 추가였지만, useMutation에서 옵션으로 ```meta: { ignoreGlobalError: true }```을 추가하여 전역 에러 핸들링을 선택적으로 제외할 수 있습니다.

> [!IMPORTANT]
> useMutation에서 직접 에러 핸들링을 하게 되면, 전역 에러 핸들링은 적용되지 않고 해당 핸들링만 적용됩니다.

### ✅ query를 활용한 커스텀 훅
- 그룹 정보 조회 query : useGroupQuery 작성

### ✅ mutation을 활용한 커스텀 훅
- 그룹 정보 수정 mutation : usePatchGroup 작성
- 그룹 정보 조회 mutation : useDeleteGroup 작성

### ✅ 기타
- staleTime, gcTime 상수 추가
- Group, GroupCard 타입 정의
- Group 정보 조회, 수정 요청 함수 작성
- Group 삭제 요청 함수 작성

### ✅ 페이지 완성
- 그룹 정보 페이지 API 연동 및 조건부 랜더링 추가
- 그룹 삭제 모달 API 연동

## 📸 스크린샷(선택)
### 그룹 정보 페이지 - 정보 조회 및 수정(수정은 방장만 가능)
| Desktop | Mobile |
|--|--|
| ![1](https://github.com/user-attachments/assets/b612f0ad-c6f8-419e-b65e-5fd56d3c6959) | ![2](https://github.com/user-attachments/assets/885419ee-20ad-4a58-96fa-dafa5ad92a97) |

### 그룹 정보 페이지 - 그룹원 접속시 모습
| Desktop | Mobile |
|--|--|
| ![3](https://github.com/user-attachments/assets/ef43ddc3-f2a1-4e10-a235-db278c449747) | ![4](https://github.com/user-attachments/assets/ff514a86-8451-4501-a816-f0908751402f) |

### 그룹 정보 페이지 - 그룹 삭제 모달(삭제는 방장만 가능)
| Desktop | Mobile |
|--|--|
| ![5](https://github.com/user-attachments/assets/37858c52-849a-4c0a-aa19-c5078cf64924) | ![6](https://github.com/user-attachments/assets/34a5ea36-7e1b-4fd8-a208-d6e7e75e3b87) |

## 💬리뷰 요구사항(선택)

close #43 
