### PR TITLE
[Feat] API 요청 및 응답 기본 타입 정의 및 예시

### DIFF
--- a/src/app/quizbook/(no-layout)/post/@modal/add/_components/AddQuizForm/index.tsx
+++ b/src/app/quizbook/(no-layout)/post/@modal/add/_components/AddQuizForm/index.tsx
@@ -7,15 +7,18 @@ import { FormProvider, useForm, useWatch } from 'react-hook-form'
 import { CustomInput } from '@/components'
 import AnswerInput from './AnswerInput'
 import { useEffect } from 'react'
-import { AddQuizFormValues, addQuizSchema } from '../../../../_schema/add-quiz'
 import { usePostQuizbookStore } from '@/store/quizbook'
 import { useRouter } from 'next/navigation'
+import {
+    AddQuizFormData,
+    addQuizSchema,
+} from '@/types/schemas/quizbook/add-quiz.schema'
 
 export default function AddQuizForm() {
     const { addQuiz } = usePostQuizbookStore()
     const router = useRouter()
 
-    const methods = useForm<AddQuizFormValues>({
+    const methods = useForm<AddQuizFormData>({
         resolver: zodResolver(addQuizSchema),
         defaultValues: {
             type: QUIZ_TYPE.OX,
@@ -25,7 +28,7 @@ export default function AddQuizForm() {
     const { handleSubmit, setValue, unregister, control } = methods
     const type = useWatch({ control, name: 'type' })
 
-    const onSubmit = (data: AddQuizFormValues) => {
+    const onSubmit = (data: AddQuizFormData) => {
         addQuiz(data)
         router.back()
     }

--- a/src/app/quizbook/(no-layout)/post/@modal/add/_components/AddQuizForm/index.tsx
+++ b/src/app/quizbook/(no-layout)/post/@modal/add/_components/AddQuizForm/index.tsx
@@ -9,10 +9,7 @@ import AnswerInput from './AnswerInput'
 import { useEffect } from 'react'
 import { usePostQuizbookStore } from '@/store/quizbook'
 import { useRouter } from 'next/navigation'
-import {
-    AddQuizFormData,
-    addQuizSchema,
-} from '@/types/schemas/quizbook/add-quiz.schema'
+import { AddQuizFormData, addQuizSchema } from '@/types/schemas/quizbook'
 
 export default function AddQuizForm() {
     const { addQuiz } = usePostQuizbookStore()

--- a/src/app/quizbook/(no-layout)/post/_components/PostQuizbookForm/AddedQuiz.tsx
+++ b/src/app/quizbook/(no-layout)/post/_components/PostQuizbookForm/AddedQuiz.tsx
@@ -2,13 +2,13 @@
 
 import CloseSvg from '@/assets/svgs/close.svg'
 
-import { PostQuiz } from '@/types/quiz'
 import AddedQuizField from './AddedQuizField'
 import { QUIZ_TYPE } from '@/constants/quiz'
 import { usePostQuizbookStore } from '@/store/quizbook'
+import { AddQuizFormData } from '@/types/schemas/quizbook/add-quiz.schema'
 
 interface Props {
-    quiz: PostQuiz
+    quiz: AddQuizFormData
     idx: number
 }
 

--- a/src/app/quizbook/(no-layout)/post/_components/PostQuizbookForm/index.tsx
+++ b/src/app/quizbook/(no-layout)/post/_components/PostQuizbookForm/index.tsx
@@ -4,19 +4,19 @@ import PlusSvg from '@/assets/svgs/plus.svg'
 
 import { usePostQuizbookStore } from '@/store/quizbook'
 import { FormProvider, useForm } from 'react-hook-form'
-import {
-    PostQuizbookFormValues,
-    postQuizbookSchema,
-} from '../../_schema/post-quizbook'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { CustomInput, CustomSelect } from '@/components'
 import { QUIZBOOK_CATEGORY } from '@/constants/quizbook'
 import AddedQuiz from './AddedQuiz'
 import Link from 'next/link'
 import { useEffect } from 'react'
+import {
+    PostQuizbookFormData,
+    postQuizbookSchema,
+} from '@/types/schemas/quizbook/post-quizbook.schema'
 
 export default function PostQuizbookForm() {
-    const methods = useForm<PostQuizbookFormValues>({
+    const methods = useForm<PostQuizbookFormData>({
         resolver: zodResolver(postQuizbookSchema),
         mode: 'onChange',
         defaultValues: {
@@ -30,7 +30,7 @@ export default function PostQuizbookForm() {
 
     const { quizList, resetQuizList } = usePostQuizbookStore()
 
-    const onSubmit = (data: PostQuizbookFormValues) => {
+    const onSubmit = (data: PostQuizbookFormData) => {
         // TODO: API 연동 로직 및 페이지 이동
         console.log(data)
 

--- a/src/app/quizbook/(no-layout)/post/_components/PostQuizbookForm/index.tsx
+++ b/src/app/quizbook/(no-layout)/post/_components/PostQuizbookForm/index.tsx
@@ -5,17 +5,25 @@ import PlusSvg from '@/assets/svgs/plus.svg'
 import { usePostQuizbookStore } from '@/store/quizbook'
 import { FormProvider, useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { CustomInput, CustomSelect } from '@/components'
+import { CustomInput, CustomSelect, LoopAnimation } from '@/components'
 import { QUIZBOOK_CATEGORY } from '@/constants/quizbook'
 import AddedQuiz from './AddedQuiz'
 import Link from 'next/link'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
+import { postQuizbook } from '@/lib/api/quizbook'
+import { useRouter } from 'next/navigation'
+import { toast } from 'sonner'
+import { AxiosError } from 'axios'
+import { ErrorResponse } from '@/types/base'
+import clsx from 'clsx'
 import {
     PostQuizbookFormData,
     postQuizbookSchema,
-} from '@/types/schemas/quizbook/post-quizbook.schema'
+} from '@/types/schemas/quizbook'
 
 export default function PostQuizbookForm() {
+    const [isLoading, setIsLoading] = useState(false)
+    const router = useRouter()
     const methods = useForm<PostQuizbookFormData>({
         resolver: zodResolver(postQuizbookSchema),
         mode: 'onChange',
@@ -25,17 +33,24 @@ export default function PostQuizbookForm() {
             quizList: [],
         },
     })
-
     const { handleSubmit, setValue, reset } = methods
-
     const { quizList, resetQuizList } = usePostQuizbookStore()
 
-    const onSubmit = (data: PostQuizbookFormData) => {
-        // TODO: API 연동 로직 및 페이지 이동
-        console.log(data)
+    const onSubmit = async (data: PostQuizbookFormData) => {
+        try {
+            setIsLoading(true)
+            await postQuizbook(data)
 
-        resetQuizList()
-        reset()
+            setIsLoading(false)
+            resetQuizList()
+            reset()
+            router.push('/quizbook')
+        } catch (e) {
+            const error = e as AxiosError<ErrorResponse>
+
+            setIsLoading(false)
+            toast.error(error.response?.data.message || error.message)
+        }
     }
 
     // TODO: AUTO SAVE 기능 추가
@@ -74,6 +89,14 @@ export default function PostQuizbookForm() {
                     placeholder="제목을 입력해주세요."
                 />
 
+                {/* 설명 영역 */}
+                <CustomInput
+                    id="description"
+                    name="description"
+                    label="설명"
+                    placeholder="간략한 설명을 입력해주세요."
+                />
+
                 {/* 추가 카드 리스트 영역 */}
                 <div className="flex w-full flex-1 flex-col gap-1">
                     <span className="text-mobile-body-sm font-regular text-gray-500 md:text-pc-body-sm">
@@ -100,11 +123,18 @@ export default function PostQuizbookForm() {
                     <PlusSvg className="h-[24px] w-[24px]" />
                 </Link>
                 <button
+                    disabled={isLoading}
                     type="submit"
                     form="post-quizbook-form"
-                    className="btn-solid btn-mobile-lg w-full md:btn-pc-lg"
+                    className={clsx(
+                        'btn-solid btn-mobile-lg w-full md:btn-pc-lg',
+                        {
+                            'btn-loading': isLoading,
+                        },
+                    )}
                 >
-                    생성하기
+                    {isLoading && <LoopAnimation />}
+                    {isLoading ? '생성중...' : '생성하기'}
                 </button>
             </div>
         </FormProvider>

--- a/src/hooks/queries/group/useGroupQuery.ts
+++ b/src/hooks/queries/group/useGroupQuery.ts
@@ -1,6 +1,6 @@
 import { GcTime } from '@/constants/common/gcTime'
 import { StaleTime } from '@/constants/common/staleTime'
-import { getGroup } from '@/lib/api'
+import { getGroup } from '@/lib/api/group'
 import { useQuery } from '@tanstack/react-query'
 
 /**

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,2 +1,0 @@
-export * from './base'
-export * from './group'

--- a/src/lib/api/quizbook/getQuizbookList.ts
+++ b/src/lib/api/quizbook/getQuizbookList.ts
@@ -3,6 +3,11 @@ import axiosInstance from '../base'
 import { PaginationResponse } from '@/types/base'
 import { Quizbook } from '@/types/quizbook'
 
+/**
+ * 문제집 리스트 조회
+ * @param params 쿼리 Parmas(QuizbookListParmas 타입)
+ * @returns 문제집 리스트(Quizbook[] 타입)
+ */
 export const getQuizbookList = async (params: QuizbookListParams = {}) => {
     const res = await axiosInstance.get<PaginationResponse<Quizbook<string>[]>>(
         '/quizbook',

--- a/src/lib/api/quizbook/getQuizbookList.ts
+++ b/src/lib/api/quizbook/getQuizbookList.ts
@@ -4,7 +4,7 @@ import { PaginationResponse } from '@/types/base'
 import { Quizbook } from '@/types/quizbook'
 
 export const getQuizbookList = async (params: QuizbookListParams = {}) => {
-    const res = await axiosInstance.get<PaginationResponse<Quizbook[]>>(
+    const res = await axiosInstance.get<PaginationResponse<Quizbook<string>[]>>(
         '/quizbook',
         { params },
     )

--- a/src/lib/api/quizbook/getQuizbookList.ts
+++ b/src/lib/api/quizbook/getQuizbookList.ts
@@ -1,0 +1,13 @@
+import { QuizbookListParams } from '@/types/api/quizbook'
+import axiosInstance from '../base'
+import { PaginationResponse } from '@/types/base'
+import { Quizbook } from '@/types/quizbook'
+
+export const getQuizbookList = async (params: QuizbookListParams = {}) => {
+    const res = await axiosInstance.get<PaginationResponse<Quizbook[]>>(
+        '/quizbook',
+        { params },
+    )
+
+    return res.data
+}

--- a/src/lib/api/quizbook/getQuizbookMeta.ts
+++ b/src/lib/api/quizbook/getQuizbookMeta.ts
@@ -1,0 +1,42 @@
+import { Response } from '@/types/base'
+import { QuizbookMeta } from '@/types/quizbook'
+
+/**
+ * 문제집 메타데이터 조회
+ * Next fetch 사용
+ * @param quizbookId 조회할 문제집의 ObjectId
+ * @returns 문제집의 메타데이터(QuizbookMeta 타입)
+ */
+export const getQuizbookMeta = async (
+    quizbookId: string,
+): Promise<QuizbookMeta> => {
+    try {
+        const res = await fetch(
+            `${process.env.NEXT_PUBLIC_API_URL}/quizbook/${quizbookId}/meta-data`,
+            {
+                method: 'GET',
+                cache: 'force-cache',
+                next: {
+                    tags: [`quizbook-meta-${quizbookId}`],
+                    revalidate: false,
+                },
+            },
+        )
+
+        if (!res.ok) {
+            const error = await res.json().catch(() => null)
+            const msg =
+                error.message ??
+                `문제집의 메타데이터 조회 실패 (status: ${res.status})`
+
+            throw new Error(msg)
+        }
+
+        const data: Response<QuizbookMeta> = await res.json()
+        return data.result
+    } catch (e) {
+        if (e instanceof Error) throw e
+
+        throw new Error('알 수 없는 에러가 발생했습니다.')
+    }
+}

--- a/src/lib/api/quizbook/getQuizbookStates.ts
+++ b/src/lib/api/quizbook/getQuizbookStates.ts
@@ -1,0 +1,16 @@
+import { QuizbookStates } from '@/types/quizbook'
+import axiosInstance from '../base'
+import { Response } from '@/types/base'
+
+/**
+ * 문제집 통계 정보 조회
+ * @param quizbookId 조회할 문제집의 ObjectId
+ * @returns 문제집 통계 정보(QuizbookStates 타입)
+ */
+export const getQuizbookStates = async (quizbookId: string) => {
+    const res = await axiosInstance.get<Response<QuizbookStates>>(
+        `/quizbook/${quizbookId}/states`,
+    )
+
+    return res.data.result
+}

--- a/src/lib/api/quizbook/getQuizbookUserFlags.ts
+++ b/src/lib/api/quizbook/getQuizbookUserFlags.ts
@@ -1,0 +1,11 @@
+import { Response } from '@/types/base'
+import axiosInstance from '../base'
+import { QuizbookUserFlags } from '@/types/quizbook'
+
+export const getQuizbookUserFlags = async (quizbookId: string) => {
+    const res = await axiosInstance.get<Response<QuizbookUserFlags>>(
+        `/quizbook/${quizbookId}/user-flags`,
+    )
+
+    return res.data.result
+}

--- a/src/lib/api/quizbook/getQuizbookUserFlags.ts
+++ b/src/lib/api/quizbook/getQuizbookUserFlags.ts
@@ -2,6 +2,11 @@ import { Response } from '@/types/base'
 import axiosInstance from '../base'
 import { QuizbookUserFlags } from '@/types/quizbook'
 
+/**
+ * 문제집 유저 플래그 조회
+ * @param quizbookId 조회할 문제집의 ObjectId
+ * @returns 문제집의 유저 플래그 정보(QuizbookUserFlags 타입)
+ */
 export const getQuizbookUserFlags = async (quizbookId: string) => {
     const res = await axiosInstance.get<Response<QuizbookUserFlags>>(
         `/quizbook/${quizbookId}/user-flags`,

--- a/src/lib/api/quizbook/index.ts
+++ b/src/lib/api/quizbook/index.ts
@@ -1,0 +1,5 @@
+export * from './postQuizbook'
+export * from './getQuizbookStates'
+export * from './getQuizbookMeta'
+export * from './getQuizbookUserFlags'
+export * from './getQuizbookList'

--- a/src/lib/api/quizbook/postQuizbook.ts
+++ b/src/lib/api/quizbook/postQuizbook.ts
@@ -1,0 +1,9 @@
+import { PostQuizbookFormData } from '@/types/schemas/quizbook'
+import axiosInstance from '../base'
+import { EmptyResponse } from '@/types/base'
+
+export const postQuizbook = async (body: PostQuizbookFormData) => {
+    const res = await axiosInstance.post<EmptyResponse>('/quizbook', body)
+
+    return res.data
+}

--- a/src/lib/api/quizbook/postQuizbook.ts
+++ b/src/lib/api/quizbook/postQuizbook.ts
@@ -2,6 +2,11 @@ import { PostQuizbookFormData } from '@/types/schemas/quizbook'
 import axiosInstance from '../base'
 import { EmptyResponse } from '@/types/base'
 
+/**
+ * 문제집 생성
+ * @param body 생성할 문제집의 FormData
+ * @returns 빈 응답 반환
+ */
 export const postQuizbook = async (body: PostQuizbookFormData) => {
     const res = await axiosInstance.post<EmptyResponse>('/quizbook', body)
 

--- a/src/store/quizbook/postQuizbookStore.ts
+++ b/src/store/quizbook/postQuizbookStore.ts
@@ -1,9 +1,9 @@
-import { PostQuiz } from '@/types/quiz'
+import { AddQuizFormData } from '@/types/schemas/quizbook/add-quiz.schema'
 import { create } from 'zustand'
 
 interface PostQuizbookStore {
-    quizList: PostQuiz[]
-    addQuiz: (quiz: PostQuiz) => void
+    quizList: AddQuizFormData[]
+    addQuiz: (quiz: AddQuizFormData) => void
     removeQuiz: (idx: number) => void
     resetQuizList: () => void
 }

--- a/src/types/api/base.d.ts
+++ b/src/types/api/base.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Pagination 적용 쿼리 Params 타입
+ */
+export interface PaginationParams {
+    cursor?: string
+    limit?: number
+}

--- a/src/types/api/quizbook.d.ts
+++ b/src/types/api/quizbook.d.ts
@@ -1,0 +1,13 @@
+import { CategoryType } from '@/constants/common/category'
+import { PaginationParams } from './base'
+
+export type QuizbookSortType = 'latest' | 'rating'
+
+/**
+ * 문제집 리스트 조회 쿼리 Params 타입
+ */
+export interface QuizbookListParams extends PaginationParams {
+    keyword?: string
+    category?: CategoryType
+    sort?: QuizbookSortType
+}

--- a/src/types/base.d.ts
+++ b/src/types/base.d.ts
@@ -12,7 +12,7 @@ export interface Response<T = unknown> {
  */
 export type PaginationResponse<T> = Response<{
     data: T
-    nextCursor?: Record<string, number | string> | null
+    nextCursor: Record<string, number | string> | null
     totalCount: number
 }>
 

--- a/src/types/base.d.ts
+++ b/src/types/base.d.ts
@@ -1,0 +1,32 @@
+/**
+ * 성공 응답 타입
+ */
+export interface Response<T = unknown> {
+    status: number
+    message: string
+    result: T
+}
+
+/**
+ * 성공 응답(With Pagination) 타입
+ */
+export type PaginationResponse<T> = Response<{
+    data: T
+    nextCursor?: Record<string, number | string> | null
+    totalCount: number
+}>
+
+/**
+ * 성공 응답(Without Result) 타입
+ */
+export type EmptyResponse = Omit<BaseResponse<void>, 'result'>
+
+/**
+ * 에러 응답 타입
+ */
+export interface ErrorResponse {
+    statusCode: number
+    timestamp: string
+    path: string
+    message: string
+}

--- a/src/types/quiz.d.ts
+++ b/src/types/quiz.d.ts
@@ -9,5 +9,5 @@ export interface Quiz {
     type: QuizType
     question: string
     optionList?: string[]
-    answer?: string
+    answer: string
 }

--- a/src/types/quiz.d.ts
+++ b/src/types/quiz.d.ts
@@ -3,18 +3,6 @@ import { QUIZ_TYPE } from '@/constants/quiz'
 // Quiz > type 필드 타입
 export type QuizType = (typeof QUIZ_TYPE)[keyof typeof QUIZ_TYPE]
 
-// AddedQuiz 타입
-export type PostQuiz =
-    | { type: typeof QUIZ_TYPE.OX; question: string; answer: 'O' | 'X' }
-    | {
-          type: typeof QUIZ_TYPE.MULTIPLE
-          question: string
-          answer: string
-          optionList: string[]
-      }
-    | { type: typeof QUIZ_TYPE.SHORT; question: string; answer: string }
-    | { type: typeof QUIZ_TYPE.LONG; question: string; answer: string }
-
 // Quiz 타입
 export interface Quiz {
     _id: string

--- a/src/types/quizbook.d.ts
+++ b/src/types/quizbook.d.ts
@@ -1,9 +1,13 @@
 import { QUIZBOOK_CATEGORY } from '@/constants/quizbook'
 import { Author } from '@/types/user'
+import { Quiz } from './quiz'
 
 export type QuizbookCategoryType =
     (typeof QUIZBOOK_CATEGORY)[keyof typeof QUIZBOOK_CATEGORY]
 
+/**
+ * 문제집 전체 타입
+ */
 export interface Quizbook<T = unknown> {
     _id: string
     title: string
@@ -11,6 +15,7 @@ export interface Quizbook<T = unknown> {
     category: QuizbookCategoryType
     solvedCount: number
     solvedScore: number
+    totalScore: number
     reviewCount: number
     reviewScore: number
     reviewRating: number
@@ -19,6 +24,43 @@ export interface Quizbook<T = unknown> {
     author: Author
     isLiked: boolean
     isStudied: boolean
+    createdAt: string
+    updatedAt: string
+}
+
+/**
+ * 문제집의 메타 정보 전용 타입
+ */
+export interface QuizbookMeta {
+    _id: string
+    title: string
+    description: string
+    category: QuizbookCategoryType
+    quizList: Quiz[]
+    totalScore: number
+    author: Author
+}
+
+/**
+ * 문제집의 유저 플래그 전용 타입
+ */
+export interface QuizbookUserFlags {
+    _id: string
+    isLiked: boolean
+    isStudied: boolean
+}
+
+/**
+ * 문제집의 통계 정보 전용 타입
+ */
+export interface QuizbookStates {
+    _id: string
+    solvedCount: number
+    solvedScore: number
+    totalScore: number
+    reviewCount: number
+    reviewScore: number
+    reviewRating: number
     createdAt: string
     updatedAt: string
 }

--- a/src/types/schemas/quizbook/add-quiz.schema.ts
+++ b/src/types/schemas/quizbook/add-quiz.schema.ts
@@ -1,7 +1,7 @@
 import { QUIZ_TYPE } from '@/constants/quiz'
-import * as z from 'zod'
+import { z } from 'zod'
 
-const baseSchema = z.object({
+const schema = z.object({
     type: z.enum(
         [QUIZ_TYPE.OX, QUIZ_TYPE.MULTIPLE, QUIZ_TYPE.SHORT, QUIZ_TYPE.LONG],
         {
@@ -11,14 +11,14 @@ const baseSchema = z.object({
     question: z.string().min(1, '질문을 입력해주세요.'),
 })
 
-const oxSchema = baseSchema.extend({
+const oxSchema = schema.extend({
     type: z.literal(QUIZ_TYPE.OX),
     answer: z.enum(['O', 'X'], {
         errorMap: () => ({ message: '정답을 선택해주세요.' }),
     }),
 })
 
-const multipleSchema = baseSchema.extend({
+const multipleSchema = schema.extend({
     type: z.literal(QUIZ_TYPE.MULTIPLE),
     optionList: z
         .array(z.string().min(1, '빈 선택지는 허용되지 않습니다.'))
@@ -29,12 +29,12 @@ const multipleSchema = baseSchema.extend({
     answer: z.string().min(1, '정답을 선택해주세요.'),
 })
 
-const shortSchema = baseSchema.extend({
+const shortSchema = schema.extend({
     type: z.literal(QUIZ_TYPE.SHORT),
     answer: z.string().min(1, '정답을 입력해주세요.'),
 })
 
-const longSchema = baseSchema.extend({
+const longSchema = schema.extend({
     type: z.literal(QUIZ_TYPE.LONG),
     answer: z.string().min(1, '답안을 입력해주세요.'),
 })
@@ -46,4 +46,4 @@ export const addQuizSchema = z.discriminatedUnion('type', [
     longSchema,
 ])
 
-export type AddQuizFormValues = z.infer<typeof addQuizSchema>
+export type AddQuizFormData = z.infer<typeof addQuizSchema>

--- a/src/types/schemas/quizbook/index.ts
+++ b/src/types/schemas/quizbook/index.ts
@@ -1,0 +1,2 @@
+export * from './add-quiz.schema'
+export * from './post-quizbook.schema'

--- a/src/types/schemas/quizbook/post-quizbook.schema.ts
+++ b/src/types/schemas/quizbook/post-quizbook.schema.ts
@@ -15,6 +15,7 @@ export const postQuizbookSchema = z.object({
         ],
         { errorMap: () => ({ message: '카테고리를 선택해주세요.' }) },
     ),
+    description: z.string().min(1, '설명을 입력해주세요.'),
     quizList: z.array(addQuizSchema).min(1, '퀴즈를 1개 이상 추가해주세요.'),
 })
 

--- a/src/types/schemas/quizbook/post-quizbook.schema.ts
+++ b/src/types/schemas/quizbook/post-quizbook.schema.ts
@@ -1,8 +1,6 @@
 import { QUIZBOOK_CATEGORY } from '@/constants/quizbook'
-import * as z from 'zod'
-import { addQuizSchema } from './add-quiz'
-
-export type PostQuizbookFormValues = z.infer<typeof postQuizbookSchema>
+import { z } from 'zod'
+import { addQuizSchema } from './add-quiz.schema'
 
 export const postQuizbookSchema = z.object({
     title: z.string().min(1, '제목을 입력해주세요.'),
@@ -19,3 +17,5 @@ export const postQuizbookSchema = z.object({
     ),
     quizList: z.array(addQuizSchema).min(1, '퀴즈를 1개 이상 추가해주세요.'),
 })
+
+export type PostQuizbookFormData = z.infer<typeof postQuizbookSchema>


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약
- 공통 응답 타입 정의
- 공통 쿼리 Params 타입 정의
- 문제집 관련 API 요청 로직 작성
- 문제집 등록 페이지 API 연동

<br/>
<br/>
<br/>

## 📝 작업 내용
### ✅ 폴더 구조 정리
- `/lib/api/[도메인 폴더]`
  - 각 API 요청 메서드 단일 파일로 작성
  - 도메인 폴더 내부에서만 `barrel export`
- `/types/[도메인].d.ts`
  - 각 API 요청의 응답값 타입을 도메인별 파일에 작성
  - `barrel export` 금지
- `/types/api/[도메인].d.ts`
  - 각 API 요청의 필요 Params를 도메인별 파일에 작성
  - `barrel export` 금지
- `/types/schemas/[도메인 폴더]`
  - 폴더 하위에 사용처 별로 파일(ex: `add-quiz.schema.ts`) 생성 후 `zod` 스키마와 `FormValues` 타입을 같이 `export`
  - 도메인 폴더 내부에서만 `barrel export`
- `hooks/queries` 및 `hooks/mutations`
  - 하위에 도메인별 폴더 생성 후 쿼리 훅 작성
  - 상단 `barrel export` 금지
  - 도메인별 폴더 내부에서만 `barrel export`

<br/>
<br/>

### ✅ 공통 응답 타입 정의
🏷️**PaginationParams 타입**
- `types/api/base.d.ts`
https://github.com/QuizBank-Dev/QuizBank-FE/blob/4ff7ee2847e1addcee249ee4e5498afa48aed307/src/types/api/base.d.ts#L4-L7
- Pagination이 적용된 API의 `쿼리 Params` 기본 타입을 정의했습니다.
- `extends` 하여 타입 확장을 하여 사용하시거나 단일 사용 해주시면 됩니다.

<br/>

🏷️**Response<T> 타입**
- `types/base.d.ts`
https://github.com/QuizBank-Dev/QuizBank-FE/blob/4ff7ee2847e1addcee249ee4e5498afa48aed307/src/types/base.d.ts#L4-L8
- `result`가 포함된 성공응답 래퍼 타입입니다.
- 제네릭을 통해 `result`의 타입 정의 후 사용해 주시면 됩니다.

<br/>

🏷️**EmptyResponse 타입**
- `types/base.d.ts`
https://github.com/QuizBank-Dev/QuizBank-FE/blob/4ff7ee2847e1addcee249ee4e5498afa48aed307/src/types/base.d.ts#L22
- `result`가 없는 단순 성공응답 래퍼 타입입니다.
- 단일 사용 해주시면 됩니다.

<br/>

🏷️**ErrorResponse 타입**
- `types/base.d.ts`
https://github.com/QuizBank-Dev/QuizBank-FE/blob/4ff7ee2847e1addcee249ee4e5498afa48aed307/src/types/base.d.ts#L27-L32
- 에러 응답 래퍼 타입입니다.
- 사용할 일은 많이 없겠지만 백엔드 서버의 에러 응답값과 통일하기 위하여 정의하였습니다.

<br/>

🏷️**PaginationResponse<T> 타입**
- `types/base.d.ts`
https://github.com/QuizBank-Dev/QuizBank-FE/blob/4ff7ee2847e1addcee249ee4e5498afa48aed307/src/types/base.d.ts#L13-L17
- 페이지네이션이 적용된 API의 성공응답 래퍼 타입입니다.
- `Response<T>` 타입과 동일하게 제네릭에 응답값 타입을 정의 후 사용하시면 됩니다.

<br/>
<br/>

### ✅ 문제집 관련 API 요청 메서드 작성
🏷️**getQuizbookList**
https://github.com/QuizBank-Dev/QuizBank-FE/blob/438a82db9c96540c584869f3d44c532e5e587598/src/lib/api/quizbook/getQuizbookList.ts#L6-L13
- 문제집 리스트 조회
- `PaginationResponse<T>`를 예시 하기 위해 작성했습니다.
- 위와 같이 명시하여 사용해 주시면 됩니다.
https://github.com/QuizBank-Dev/QuizBank-FE/blob/438a82db9c96540c584869f3d44c532e5e587598/src/types/api/quizbook.d.ts#L9-L13
- 위와 같이 `PaginationParams`을 `extends` 하여 `Params 타입`을 정의해주시면 됩니다.
  ```ts
  const res = await getQuizbookList({
          cursor: JSON.stringify({ _id: '68003cf91c934b0f49d23251' }),
  })
  ```
- 커서를 이용하여 다음 리스트를 불러 올 경우 위와 같이 응답으로 온 `nextCursor`를 `JSON.stringfy()` 하여 `Params`로 넘겨주면 됩니다.

<br/>

🏷️**getQuizbookStates**
https://github.com/QuizBank-Dev/QuizBank-FE/blob/e293fc8c4f9ad2a79c262fb042acd1176b82bd88/src/lib/api/quizbook/getQuizbookStates.ts#L10-L16
- 문제집 통계 정보 조회

<br/>

🏷️**getQuizbookUserFlags**
https://github.com/QuizBank-Dev/QuizBank-FE/blob/e293fc8c4f9ad2a79c262fb042acd1176b82bd88/src/lib/api/quizbook/getQuizbookUserFlags.ts#L10-L16
- 문제집 유저 플래그 조회

<br/>

🏷️**postQuizbook**
https://github.com/QuizBank-Dev/QuizBank-FE/blob/f2ddcf275443380e703f0e035039e10c2dd85278/src/lib/api/quizbook/postQuizbook.ts#L10-L14
- 문제집 등록

<br/>

🏷️**getQuizbookMeta**
https://github.com/QuizBank-Dev/QuizBank-FE/blob/f2ddcf275443380e703f0e035039e10c2dd85278/src/lib/api/quizbook/getQuizbookMeta.ts#L10-L42
- Next.js의 캐싱 활용을 위해 `fetch`로 작성되었습니다.
- 추후 동일 요청 로직이 `axios` 요청으로 필요할 시 추가 작성하겠습니다.

<br/>
<br/>

### ✅ 문제집 등록 페이지 완성
- 문제집 등록 페이지를 완성했습니다.

<br/>
<br/>
<br/>

## 💬리뷰 요구사항
- 더 좋은 구성 또는 현 로직에 문제가 있다면 디코나 코멘트 남겨주시면 좋을 듯 합니다.
