### PR TITLE
[Feat] 유저 메뉴 컴포넌트 퍼블리싱 및 로그아웃 API 연동

### DIFF
--- a/src/components/DesktopHeader/UserMenu.tsx
+++ b/src/components/DesktopHeader/UserMenu.tsx
@@ -7,11 +7,14 @@ import clsx from 'clsx'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import LoopAnimation from '../LoopAnimation'
+import { useState } from 'react'
+import ProfileMenu from '@/components/ProfileMenu'
 
 export default function UserMenu() {
     const { data: user, isLoading } = useCurrentUser()
 
     const router = useRouter()
+    const [isProfileOpen, setIsProfileOpen] = useState(false)
 
     if (!user)
         return (
@@ -39,8 +42,11 @@ export default function UserMenu() {
             />
             <User
                 className="size-6 cursor-pointer"
-                onClick={() => router.push('/my-page')}
+                onClick={() => setIsProfileOpen(true)}
             />
+            {isProfileOpen && (
+                <ProfileMenu onClose={() => setIsProfileOpen(false)} />
+            )}
         </div>
     )
 }

--- a/src/components/MobileHeader/UserMenu.tsx
+++ b/src/components/MobileHeader/UserMenu.tsx
@@ -6,11 +6,14 @@ import UserIcon from '@/assets/svgs/user.svg'
 import { useCurrentUser } from '@/hooks/queries/user'
 import { useRouter } from 'next/navigation'
 import LoopAnimation from '../LoopAnimation'
+import ProfileMenu from '@/components/ProfileMenu'
+import { useState } from 'react'
 
 export default function UserMenu() {
     const { data: user, isLoading } = useCurrentUser()
 
     const router = useRouter()
+    const [isProfileOpen, setIsProfileOpen] = useState(false)
 
     if (!user)
         return (
@@ -36,8 +39,11 @@ export default function UserMenu() {
             />
             <UserIcon
                 className="size-6 cursor-pointer"
-                onClick={() => router.push('/my-page')}
+                onClick={() => setIsProfileOpen(true)}
             />
+            {isProfileOpen && (
+                <ProfileMenu onClose={() => setIsProfileOpen(false)} />
+            )}
         </>
     )
 }

--- a/src/components/ProfileMenu/index.tsx
+++ b/src/components/ProfileMenu/index.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from 'react'
+import Link from 'next/link'
+import clsx from 'clsx'
+import { ProfileImage } from '@/components'
+import { useCurrentUser } from '@/hooks/queries/user'
+import { useRouter } from 'next/navigation'
+
+interface Props {
+    onClose: () => void
+}
+
+export default function ProfileMenu({ onClose }: Props) {
+    const profileRef = useRef<HTMLDivElement | null>(null)
+    const router = useRouter()
+    const { data: user } = useCurrentUser()
+
+    const handleLogout = () => {
+        // Logout API 호출
+        router.push('/login')
+    }
+
+    useEffect(() => {
+        const handleClickOutside = (e: MouseEvent) => {
+            if (
+                profileRef.current &&
+                !profileRef.current.contains(e.target as Node)
+            ) {
+                onClose()
+            }
+        }
+
+        document.addEventListener('mousedown', handleClickOutside)
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside)
+        }
+    }, [onClose])
+
+    if (!user) {
+        return null
+    }
+
+    return (
+        <div
+            ref={profileRef}
+            className={clsx(
+                'flex w-full max-w-48 flex-col gap-2 rounded-lg bg-white p-2 shadow-point',
+                'absolute right-4 top-4 z-50 md:right-2 lg:right-[calc((100%-1024px)/2)]',
+            )}
+        >
+            <div className="flex items-center gap-4 md:flex-col">
+                <div className="block md:hidden">
+                    <ProfileImage size={32} profileImg={user.profileImg} />
+                </div>
+                <div className="hidden md:block">
+                    <ProfileImage size={64} profileImg={user.profileImg} />
+                </div>
+                <div className="flex flex-col items-start gap-2 md:items-center">
+                    <p className="text-mobile-body-lg font-semi-bold md:text-pc-body-lg">
+                        {user.nickname}
+                    </p>
+                    <Link
+                        href="/my-page"
+                        className="text-mobile-body-sm text-point-500 underline md:text-pc-body-sm"
+                        // onClick={onClose}
+                    >
+                        내 프로필 보기
+                    </Link>
+                </div>
+            </div>
+            <button
+                className="btn-solid btn-mobile-md md:btn-pc-md"
+                onClick={handleLogout}
+            >
+                로그아웃
+            </button>
+        </div>
+    )
+}

--- a/src/components/ProfileMenu/index.tsx
+++ b/src/components/ProfileMenu/index.tsx
@@ -1,9 +1,12 @@
 import { useEffect, useRef } from 'react'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import clsx from 'clsx'
 import { ProfileImage } from '@/components'
 import { useCurrentUser } from '@/hooks/queries/user'
-import { useRouter } from 'next/navigation'
+import { logout } from '@/lib/api/auth'
+import { getQueryClient } from '@/lib/react-query/getQueryClient'
+import { QueryKey } from '@/constants/common/queryKey'
 
 interface Props {
     onClose: () => void
@@ -12,11 +15,16 @@ interface Props {
 export default function ProfileMenu({ onClose }: Props) {
     const profileRef = useRef<HTMLDivElement | null>(null)
     const router = useRouter()
+    const queryClient = getQueryClient()
     const { data: user } = useCurrentUser()
 
     const handleLogout = () => {
-        // Logout API 호출
-        router.push('/login')
+        logout().then(async () => {
+            router.push('/login')
+            await queryClient.invalidateQueries({
+                queryKey: QueryKey.user.DEFAULT,
+            })
+        })
     }
 
     useEffect(() => {

--- a/src/lib/api/auth/index.ts
+++ b/src/lib/api/auth/index.ts
@@ -1,0 +1,1 @@
+export * from './logout'

--- a/src/lib/api/auth/logout.ts
+++ b/src/lib/api/auth/logout.ts
@@ -1,0 +1,8 @@
+import axiosInstance from '@/lib/api/base'
+
+/**
+ * 로그아웃
+ */
+export const logout = async () => {
+    return await axiosInstance.post('v1/auth/logout')
+}


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

유저 메뉴 컴포넌트 퍼블리싱 및 로그아웃 API 연동했습니다.

## 📌 이슈 넘버

- #57

## 📝 작업 내용

### 유저 메뉴 컴포넌트 퍼블리싱

기존에 Figma에 작성되어있었지만 퍼블리싱되지 않았던 유저 메뉴 컴포넌트를 퍼블리싱했습니다.

### 로그아웃 API 연동

로그아웃 API를 연동했습니다.

## 📸 스크린샷(선택)

### 유저 메뉴 컴포넌트 퍼블리싱

| Desktop | Mobile |
|--|--|
| ![Image](https://github.com/user-attachments/assets/de975c58-9ae1-4e35-88d4-fa78fcbe1ba0) | ![Image](https://github.com/user-attachments/assets/7499e1a9-7d44-4da2-84ba-9a9218319896) |

## 💬리뷰 요구사항(선택)

