### PR TITLE
[Feat] 문제집카드 찜 버튼에 mutation 연동

### DIFF
--- a/src/components/QuizbookCard/LikeButton.tsx
+++ b/src/components/QuizbookCard/LikeButton.tsx
@@ -2,12 +2,12 @@
 
 import { useState } from 'react'
 import clsx from 'clsx'
+import { toast } from 'sonner'
+import { useCurrentUser } from '@/hooks/queries/user'
+import { postQuizbookLike } from '@/lib/api/like'
 import { useQuizbookCardContext } from './QuizbookCardContext'
 
 import HeartFillSvg from '@/assets/svgs/heart-fill.svg'
-import { useCurrentUser } from '@/hooks/queries/user'
-import { toast } from 'sonner'
-import { postQuizbookLike } from '@/lib/api/like'
 
 interface Props {
     isLike?: boolean

--- a/src/components/QuizbookCard/LikeButton.tsx
+++ b/src/components/QuizbookCard/LikeButton.tsx
@@ -4,10 +4,10 @@ import { useState } from 'react'
 import clsx from 'clsx'
 import { toast } from 'sonner'
 import { useCurrentUser } from '@/hooks/queries/user'
-import { postQuizbookLike } from '@/lib/api/like'
 import { useQuizbookCardContext } from './QuizbookCardContext'
 
 import HeartFillSvg from '@/assets/svgs/heart-fill.svg'
+import { usePostQuizbookListLike } from '@/hooks/mutations/like'
 
 interface Props {
     isLike?: boolean
@@ -18,26 +18,19 @@ export default function LikeButton({ isLike }: Props) {
     const { data: user } = useCurrentUser()
     const [_isLike, setIsLike] = useState(isLike)
 
+    const toggleIsLike = () => {
+        setIsLike((prev) => !prev)
+    }
+
+    const { mutate: like } = usePostQuizbookListLike(quizbookId, toggleIsLike)
+
     const handleLike = () => {
         if (!user) {
             // 로그인상태가 아닌 경우
             toast('로그인이 필요한 서비스입니다.')
             return
         }
-
-        // 찜하기 클릭 로직 (API 호출)
-        postQuizbookLike(quizbookId)
-            .then(({ result: { state } }) => {
-                setIsLike(state)
-                toast(
-                    state
-                        ? '찜목록에 추가되었습니다.'
-                        : '찜목록에서 제거되었습니다.',
-                )
-            })
-            .catch(() => {
-                toast('저장 중 오류가 발생했습니다.')
-            })
+        like()
     }
 
     return (

--- a/src/hooks/mutations/like/index.ts
+++ b/src/hooks/mutations/like/index.ts
@@ -1,1 +1,2 @@
 export * from './usePostQuizbookLike'
+export * from './usePostQuizbookListLike'

--- a/src/hooks/mutations/like/usePostQuizbookListLike.ts
+++ b/src/hooks/mutations/like/usePostQuizbookListLike.ts
@@ -1,0 +1,41 @@
+import { toast } from 'sonner'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { postQuizbookLike } from '@/lib/api/like'
+
+/**
+ * 문제집리스트 페이지에서 문제집 좋아요를 진행하는 mutation
+ */
+export const usePostQuizbookListLike = (
+    quizbookId: string,
+    toggleLike: () => void,
+) => {
+    const queryClient = useQueryClient()
+
+    return useMutation({
+        mutationFn: () => postQuizbookLike(quizbookId),
+        retry: 0,
+        onMutate: () => {
+            toggleLike()
+        },
+        onError: () => {
+            toggleLike()
+            toast('저장 중 오류가 발생했습니다.')
+        },
+        onSuccess: ({ result: { state } }) => {
+            toast(
+                state
+                    ? '찜목록에 추가되었습니다.'
+                    : '찜목록에서 제거되었습니다.',
+            )
+
+            queryClient.invalidateQueries({
+                queryKey: ['quizbook'],
+            })
+            // 상세 페이지의 쿼리 무효화 (이미 방문했다면 캐시되어있음)
+            queryClient.invalidateQueries({
+                queryKey: ['quizbook-flags', quizbookId],
+                type: 'all',
+            })
+        },
+    })
+}


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

문제집카드 찜 버튼에 mutation 연동했습니다.

## 📌 이슈 넘버

- #78

## 📝 작업 내용

### mutation 작성

기존에 작성된 usePostQuizbookLike을 문제집 리스트 페이지에서 사용할 수 없어(유저 플래그 캐시에 선반영 부분에서 에러) 별도의 mutation을 작성했습니다.

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

