### PR TITLE
[Fix] 로그인 진행 시 현재 로그인된 유저 쿼리를 초기화하도록 수정

### DIFF
--- a/src/app/(auth)/login/_components/LoginForm.tsx
+++ b/src/app/(auth)/login/_components/LoginForm.tsx
@@ -5,8 +5,10 @@ import { useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import { AxiosError } from 'axios'
+import { useQueryClient } from '@tanstack/react-query'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { CustomInput } from '@/components'
+import { QueryKey } from '@/constants/common/queryKey'
 import { LoginFormData, loginSchema } from '@/types/schemas/auth'
 import { EmptyResponse } from '@/types/base'
 import { login } from '@/lib/api/auth'
@@ -15,6 +17,7 @@ import LoadingButton from '../../_components/LoadingButton'
 export default function LoginForm() {
     const router = useRouter()
     const searchParams = useSearchParams()
+    const queryClient = useQueryClient()
     const [isLoading, setIsLoading] = useState(false)
     const methods = useForm<LoginFormData>({
         resolver: zodResolver(loginSchema),
@@ -27,6 +30,10 @@ export default function LoginForm() {
             .then(() => {
                 const token = searchParams.get('token')
                 router.push(token ? `/group/invitation?token=${token}` : '/')
+                queryClient.invalidateQueries({
+                    queryKey: QueryKey.user.DEFAULT,
+                    exact: true,
+                })
             })
             .catch((error: AxiosError<EmptyResponse>) => {
                 toast(


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

로그인 진행 시 현재 로그인된 유저 쿼리를 초기화하도록 수정했습니다.

## 📌 이슈 넘버

- #84

## 📝 작업 내용

### 로그인 API 호출 후 로그인한 유저 쿼리 무효화

로그인 시 기존에 초기화되지 않았던 쿼리를 초기화했습니다.

mutation을 적용하는 것을 고민했지만 우선 현재 구현된 상태로 두고 이후 리팩토링을 진행하는 게 더 나을 것이라 생각되어 기존 방식에서 쿼리만 무효화하는 방식으로 진행했습니다.

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)
