### PR TITLE
[Feat] 마이페이지 간격 수정

### DIFF
--- a/src/app/my-page/_components/CommonPageLayout.tsx
+++ b/src/app/my-page/_components/CommonPageLayout.tsx
@@ -10,7 +10,7 @@ export default function CommonPageLayout({ title, children }: Props) {
     return (
         <>
             <MobileHeader title={title} backBtn />
-            <div className="no-scrollbar flex w-full max-w-[1056px] flex-col gap-4 overflow-auto p-4 md:flex-row md:flex-wrap md:pt-8">
+            <div className="no-scrollbar flex w-full max-w-[1056px] flex-col gap-8 overflow-auto p-4 md:flex-row md:flex-wrap md:pt-8">
                 <main className="flex flex-1 flex-col gap-4">
                     <h2 className="hidden text-mobile-title-sm font-extra-bold text-point-900 md:block md:text-pc-title-sm">
                         {title}

--- a/src/app/user/[userId]/page.tsx
+++ b/src/app/user/[userId]/page.tsx
@@ -27,7 +27,7 @@ export default async function Page({
     return (
         <OtherUserPreFetcher userId={userId} defaultData={user}>
             <MobileHeader title={user?.nickname || ''} backBtn />
-            <main className="no-scrollbar relative flex w-full max-w-[1056px] flex-col items-start gap-4 overflow-auto p-4 md:flex-row md:pt-8">
+            <main className="no-scrollbar relative flex w-full max-w-[1056px] flex-col items-start gap-8 overflow-auto p-4 md:flex-row md:pt-8">
                 <Profile />
                 <div className="flex w-full flex-1 flex-col gap-4">
                     <h2 className="hidden text-mobile-title-sm font-extra-bold text-point-900 md:block md:text-pc-title-sm">


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

페이지 간격이 디자인 시안과 달랐던 부분을 수정했습니다.

## 📌 이슈 넘버

- #83

## 📝 작업 내용

### 마이페이지 / 다른 사용자 페이지 간격 수정

페이지 간격이 디자인 시안과 달랐던 부분을 수정했습니다.

## 📸 스크린샷(선택)

### 마이페이지

| 변경전 | 변경후 |
|--|--|
| ![Image](https://github.com/user-attachments/assets/4e8dd818-5143-455d-882f-14c632d4a96b) | ![Image](https://github.com/user-attachments/assets/781413bf-0c6d-48bc-9c4b-484371ec8eb3) |

### 다른 사용자 페이지

| 변경전 | 변경후 |
|--|--|
| ![Image](https://github.com/user-attachments/assets/f15e5702-56e6-4a99-8773-9a78d0413254) | ![Image](https://github.com/user-attachments/assets/0e860f1b-d16b-4708-9e63-cabc8bb24ec4) |

## 💬리뷰 요구사항(선택)

