### PR TITLE
[FEAT] 공통 Footer 컴포넌트 개발

### DIFF
--- a/src/app/group/(layout)/page.tsx
+++ b/src/app/group/(layout)/page.tsx
@@ -1,5 +1,6 @@
 import MobileHeader from '@/components/MobileHeader'
 import GroupSearch from './_components/GroupSearch'
+import DesktopFooter from '@/components/DesktopFooter'
 
 export default function GroupPage() {
     return (
@@ -10,14 +11,17 @@ export default function GroupPage() {
             </MobileHeader>
 
             {/* 컨탠츠 */}
-            <main className="no-scrollbar flex w-full flex-1 flex-col items-center overflow-auto">
-                <div className="flex w-full max-w-[1056px] flex-col gap-4 px-4 py-4 md:py-8">
+            <div className="no-scrollbar flex h-full w-full flex-1 flex-col items-center justify-between overflow-auto">
+                <main className="flex w-full max-w-[1056px] flex-col gap-4 px-4 py-4 md:py-8">
                     <h2 className="hidden text-pc-title-sm font-extra-bold text-point-900 md:block">
                         그룹 검색
                     </h2>
                     <GroupSearch />
-                </div>
-            </main>
+                </main>
+
+                {/* 데스크탑 푸터 */}
+                <DesktopFooter />
+            </div>
         </>
     )
 }

--- a/src/app/quizbook/(layout)/layout.tsx
+++ b/src/app/quizbook/(layout)/layout.tsx
@@ -3,6 +3,7 @@ import DesktopHeader from '@/components/DesktopHeader'
 import MobileBottomNav from '@/components/MobileBottomNav'
 import MobileHeader from '@/components/MobileHeader'
 import { QuizbookListPreFetcher } from './_providers/QuizbookListPreFetcher'
+import DesktopFooter from '@/components/DesktopFooter'
 
 export default async function Layout({
     children,
@@ -24,9 +25,12 @@ export default async function Layout({
                     <MobileHeader.UserMenu />
                 </MobileHeader>
 
-                <main className="no-scrollbar flex w-full flex-1 flex-col items-center overflow-auto">
+                <div className="no-scrollbar flex h-full w-full flex-1 flex-col items-center justify-between overflow-auto">
                     {children}
-                </main>
+
+                    {/* 데스크탑 푸터 */}
+                    <DesktopFooter />
+                </div>
 
                 {/* 모바일 전용 바텀 Nav */}
                 <MobileBottomNav />

--- a/src/app/quizbook/(layout)/page.tsx
+++ b/src/app/quizbook/(layout)/page.tsx
@@ -10,9 +10,9 @@ export default async function Page({
     const params = await searchParams
 
     return (
-        <div className="flex w-full max-w-[1056px] flex-col gap-4 px-4 py-4 md:py-8">
+        <main className="flex w-full max-w-[1056px] flex-col gap-4 px-4 py-4 md:py-8">
             <SearchForm params={params} />
             <QuizbookList />
-        </div>
+        </main>
     )
 }

--- a/src/components/DesktopFooter.tsx
+++ b/src/components/DesktopFooter.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link'
+import GitHubIcon from '@/assets/login-icons/github.svg'
+import { developers } from '@/constants/developers'
+import Logo from '@/assets/svgs/logo.svg'
+
+export default function DesktopFooter() {
+    return (
+        <footer className="hidden w-full justify-center bg-gray-800 px-4 py-8 text-pc-body-sm font-semi-bold text-gray-400 md:flex">
+            <div className="flex w-full max-w-[1024px] items-end justify-between">
+                <section className="flex gap-16">
+                    <article className="flex flex-col gap-8">
+                        <Link href="/" className="flex items-center gap-4">
+                            <Logo className="h-[55px] w-[50px]" />
+                            <div className="flex flex-col">
+                                <span className="text-pc-title-md font-extra-bold leading-none text-point-500">
+                                    Quiz Bank
+                                </span>
+                                <span className="text-pc-body-md text-gray-200">
+                                    퀴즈로 배우고 성장하는 공간
+                                </span>
+                            </div>
+                        </Link>
+                        <div className="flex flex-col gap-1">
+                            <span>Contact Us : {process.env.TEAM_EMAIL}</span>
+                            <span>
+                                © 2025 Team QuizBank. All rights reserved.
+                            </span>
+                        </div>
+                    </article>
+                    <article className="flex flex-col gap-3">
+                        <span className="text-pc-body-md text-gray-200">
+                            문제집
+                        </span>
+                        <Link href={'/quizbook'}>문제집 검색</Link>
+                        <Link href={'/quizbook/post'}>문제집 생성</Link>
+                    </article>
+                    <article className="flex flex-col gap-3">
+                        <span className="text-pc-body-md text-gray-200">
+                            그룹
+                        </span>
+                        <Link href={'/group'}>그룹 검색</Link>
+                        <Link href={'/group/new'}>그룹 생성</Link>
+                    </article>
+                    <article className="flex flex-col gap-3">
+                        <span className="text-pc-body-md text-gray-200">
+                            Developers
+                        </span>
+                        {developers.map((member) => (
+                            <Link key={member.link} href={member.link}>
+                                {member.nickname}
+                            </Link>
+                        ))}
+                    </article>
+                </section>
+                <Link href={'https://github.com/QuizBank-Dev'}>
+                    <GitHubIcon />
+                </Link>
+            </div>
+        </footer>
+    )
+}

--- a/src/constants/developers.ts
+++ b/src/constants/developers.ts
@@ -1,0 +1,5 @@
+export const developers = [
+    { nickname: 'Vanlan', link: 'https://github.com/Kim-HyounSuk' },
+    { nickname: 'Pa55er', link: 'https://github.com/Pa55er' },
+    { nickname: 'ppyom', link: 'https://github.com/ppyom' },
+]


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

- 여러 페이지에 사용될 공통 Footer 컴포넌트를 개발했습니다.

## 📌 이슈 넘버

- #91 

## 📝 작업 내용

- DesktopFooter 컴포넌트 작성
- 문제집 검색 페이지에 footer 추가
- 그룹 검색 페이지에 footer 추가
- 팀이메일 관련 환경변수 추가
```shell
TEAM_EMAIL=# 팀이메일@gmail.com
```

## 📸 스크린샷(선택)

![1](https://github.com/user-attachments/assets/6072a26b-e134-447a-910a-45e7b31ec46d)

## 💬리뷰 요구사항(선택)

close #91 
