### PR TITLE
[Fix] middleware의 검사 제외 항목에 이미지 폴더 추가

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -60,5 +60,5 @@ export function middleware(request: NextRequest) {
 
 export const config = {
     // 정적 리소스 검사 제외
-    matcher: ['/((?!api|_next|favicon.ico).*)'],
+    matcher: ['/((?!api|_next|favicon.ico|jpg|badges).*)'],
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -60,5 +60,5 @@ export function middleware(request: NextRequest) {
 
 export const config = {
     // 정적 리소스 검사 제외
-    matcher: ['/((?!api|_next|favicon.ico|jpg|badges).*)'],
+    matcher: ['/((?!api|_next|favicon.ico|jpg|badges|images).*)'],
 }


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

로그인을 하지 않은 사용자가 이미지를 확인할 수 없던 오류를 수정했습니다.

## 📌 이슈 넘버

- #98

## 📝 작업 내용

### middleware 검사 제외 항목에 이미지 폴더 추가

jpgs, badges 폴더를 middleware의 검사 제외 항목에 추가했습니다.

> [!NOTE]
> 이미지 폴더가 두 개(jpgs, badges)로 나누어져있는데, 이미지를 추가할 때마다 폴더를 추가하고 middleware의 제외 항목이 계속 수정되는게 좋지 않다고 생각했습니다. 그래서 공통 이미지 저장 폴더인 images를 만들어두었으니 해당 PR 이후에 추가되는 정적 이미지는 `public/images` 폴더에 넣어주세요.

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)

