### PR TITLE
[Feat] 배포 후 발견된 이슈 수정

### DIFF
--- a/src/app/(auth)/login/@modal/default.ts
+++ b/src/app/(auth)/login/@modal/default.ts
@@ -1,0 +1,3 @@
+export default function Default() {
+    return null
+}

--- a/src/app/(auth)/login/@modal/todo/page.ts
+++ b/src/app/(auth)/login/@modal/todo/page.ts
@@ -1,0 +1,3 @@
+import { TodoModal } from '@/components/common'
+
+export default TodoModal

--- a/src/app/(auth)/login/_components/OAuthLogin/OAuthLoginButton.tsx
+++ b/src/app/(auth)/login/_components/OAuthLogin/OAuthLoginButton.tsx
@@ -1,10 +1,14 @@
 'use client'
 
 import clsx from 'clsx'
-import { OAuthBgColor, OAuthIcons } from '@/constants/common/oauthLogin'
+import {
+    OAuthBgColor,
+    OAuthIcons,
+    ValidProviderList,
+} from '@/constants/common/oauthLogin'
 import { OAuthProvider } from '@/types/api/auth'
 import { oauthLogin } from '@/lib/api/auth'
-import { useSearchParams } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 
 interface Props {
     provider: OAuthProvider
@@ -13,10 +17,15 @@ interface Props {
 
 export default function OAuthLoginButton({ provider, title }: Props) {
     const searchParams = useSearchParams()
+    const router = useRouter()
     const Icon = OAuthIcons[provider]
     const bgColor = OAuthBgColor[provider]
 
     const handleOAuthButtonClick = () => {
+        if (!ValidProviderList.includes(provider)) {
+            router.push('/login/todo')
+            return
+        }
         const token = searchParams.get('token')
         oauthLogin(provider, token ? `group/invitation?token=${token}` : '')
     }

--- a/src/app/(auth)/login/layout.tsx
+++ b/src/app/(auth)/login/layout.tsx
@@ -1,0 +1,13 @@
+interface Props {
+    children: React.ReactNode
+    modal: React.ReactNode
+}
+
+export default function Layout({ children, modal }: Props) {
+    return (
+        <>
+            {children}
+            {modal}
+        </>
+    )
+}

--- a/src/app/(auth)/login/not-found.ts
+++ b/src/app/(auth)/login/not-found.ts
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function NotFound() {
+    return redirect('/login')
+}

--- a/src/app/(auth)/signup/_components/SignupForm.tsx
+++ b/src/app/(auth)/signup/_components/SignupForm.tsx
@@ -10,9 +10,12 @@ import { useEmailVerification } from '@/hooks/useEmailVerification'
 import { SignupFormData, signupSchema } from '@/types/schemas/auth'
 import { signup } from '@/lib/api/auth'
 import LoadingButton from '../../_components/LoadingButton'
+import { useQueryClient } from '@tanstack/react-query'
+import { QueryKey } from '@/constants/common/queryKey'
 
 export default function SignupForm() {
     const router = useRouter()
+    const queryClient = useQueryClient()
     const [isLoading, setIsLoading] = useState(false)
     const methods = useForm<SignupFormData>({
         resolver: zodResolver(signupSchema),
@@ -25,7 +28,11 @@ export default function SignupForm() {
         setIsLoading(true)
         signup(data)
             .then(() => {
-                router.push('/')
+                queryClient
+                    .invalidateQueries({
+                        queryKey: QueryKey.user.DEFAULT,
+                    })
+                    .then(() => router.push('/'))
             })
             .catch(() => {
                 toast('회원가입 중 오류가 발생했습니다.')

--- a/src/app/my-page/info/@modal/change-password/_components/ChangePasswordForm.tsx
+++ b/src/app/my-page/info/@modal/change-password/_components/ChangePasswordForm.tsx
@@ -57,8 +57,8 @@ export default function ChangePasswordForm() {
                     id="password"
                     name="password"
                     type="password"
-                    label="이전 비밀번호"
-                    placeholder="현재 비밀번호를 입력해주세요"
+                    label="현재 비밀번호"
+                    placeholder="현재 사용중인 비밀번호를 입력해주세요"
                     style="solid"
                 />
                 <CustomInput

--- a/src/app/user/[userId]/_components/QuizbookList/QuizbookCard.tsx
+++ b/src/app/user/[userId]/_components/QuizbookList/QuizbookCard.tsx
@@ -9,7 +9,8 @@ type Props = Quizbook
 
 export default function QuizbookCard({ ...quizbook }: Props) {
     const router = useRouter()
-    const handleQuizbookClick = () => router.push(`/quizbook/${quizbook._id}`)
+    const handleQuizbookClick = () =>
+        router.push(`/quizbook/${quizbook._id}/info`)
     return (
         <Card
             id={quizbook._id}

--- a/src/constants/common/oauthLogin.ts
+++ b/src/constants/common/oauthLogin.ts
@@ -17,3 +17,5 @@ export const OAuthBgColor: Record<OAuthProvider, string> = {
     kakao: 'bg-[#FEE500]',
     naver: 'bg-[#03C75A]',
 }
+
+export const ValidProviderList: OAuthProvider[] = ['github']

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from 'next/server'
 const PUBLIC_PATHS = [
     '/',
     '/login',
+    '/login/todo', // TODO OAuth 구현 완료 시 제거
     '/signup',
     '/forgot-password',
     '/reset-password',
@@ -17,6 +18,7 @@ const PUBLIC_PATHS = [
 // 로그인이 필요없는 paths
 const SKIP_AUTH_PATHS = [
     '/login',
+    '/login/todo', // TODO OAuth 구현 완료 시 제거
     '/signup',
     '/forgot-password',
     '/reset-password',


### PR DESCRIPTION
## 📄 작업 페이지 및 내용 요약

배포 후 맡은 페이지에서 발견된 이슈들을 수정했습니다.

## 📌 이슈 넘버

- #110

## 📝 작업 내용

### 회원가입 이후 currentUser 초기화

회원가입 이후 currentUser가 초기화되지않아 헤더 및 최초 로그인 시 실행되어야하는 카테고리 선택 페이지로 넘어가지 않던 현상을 수정했습니다.

### 사용자 페이지 - 생성한 문제집카드 클릭 시 상세페이지 pathname 수정

상세페이지 pathname이 변경된 이후 해당 컴포넌트의 pathname을 변경하지 않아 발생한 오류를 수정했습니다.

### 비밀번호 변경 컴포넌트 Input 라벨 수정

기존에 "이전 비밀번호"로 되어있어 사용자 입장에서 애매하게 느껴질 수 있던 라벨을 "현재 비밀번호"로 변경하고, placeholder도 "현재 비밀번호 ..."에서 "현재 사용중인 비밀번호 ..."로 수정했습니다.

### GitHub 이외의 OAuth 로그인 버튼에 Todo 모달 추가

현재 구현되지 않은 나머지 로그인 버튼 클릭 시 Todo 모달이 열리도록 모달을 추가했습니다.

## 📸 스크린샷(선택)

## 💬리뷰 요구사항(선택)
